### PR TITLE
enforce pgm>=1.6.46 due to hotfix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "numpy>=1.20",
     "openpyxl",
     "pandas",
-    "power_grid_model>=1.6",
+    "power_grid_model>=1.6.46",
     "pyyaml",
     "structlog",
     "tqdm",


### PR DESCRIPTION
A user bumping `power-grid-model-io` to the latest version should be fine with working on the latest version of `power-grid-model`. Since we strongly recommend being on `power-grid-model>=1.4.46` due to the bugfix in that version