### PR TITLE
Pandapower Jupyter example notebook log output fix

### DIFF
--- a/docs/examples/pandapower_example.ipynb
+++ b/docs/examples/pandapower_example.ipynb
@@ -90,7 +90,7 @@
     "import warnings\n",
     "from power_grid_model_io.converters import PandaPowerConverter\n",
     "\n",
-    "warnings.filterwarnings(\"ignore\", category=FutureWarning) # Hide warnings relates to panda\n",
+    "warnings.filterwarnings(\"ignore\", category=FutureWarning) # Hide warnings related to panda\n",
     "\n",
     "pp_net = pandapower_simple_grid()\n",
     "converter = PandaPowerConverter()\n",

--- a/docs/examples/pandapower_example.ipynb
+++ b/docs/examples/pandapower_example.ipynb
@@ -708,7 +708,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.1"
+   "version": "3.10.9"
   },
   "vscode": {
    "interpreter": {

--- a/docs/examples/pandapower_example.ipynb
+++ b/docs/examples/pandapower_example.ipynb
@@ -87,10 +87,10 @@
    "outputs": [],
    "source": [
     "%%capture cap --no-stderr\n",
-    "import pandas as pd\n",
+    "import warnings\n",
     "from power_grid_model_io.converters import PandaPowerConverter\n",
     "\n",
-    "pd.set_option('future.no_silent_downcasting', True) # Hide warnings relates to panda\n",
+    "warnings.filterwarnings(\"ignore\", category=FutureWarning) # Hide warnings relates to panda\n",
     "\n",
     "pp_net = pandapower_simple_grid()\n",
     "converter = PandaPowerConverter()\n",

--- a/docs/examples/pandapower_example.ipynb
+++ b/docs/examples/pandapower_example.ipynb
@@ -87,8 +87,10 @@
    "outputs": [],
    "source": [
     "%%capture cap --no-stderr\n",
-    "\n",
+    "import pandas as pd\n",
     "from power_grid_model_io.converters import PandaPowerConverter\n",
+    "\n",
+    "pd.set_option('future.no_silent_downcasting', True) # Hide warnings relates to panda\n",
     "\n",
     "pp_net = pandapower_simple_grid()\n",
     "converter = PandaPowerConverter()\n",
@@ -706,7 +708,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.9"
+   "version": "3.12.1"
   },
   "vscode": {
    "interpreter": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ requires-python = ">=3.9"
 dependencies = [
     "numpy>=1.20",
     "openpyxl",
-    "pandas<3.0",
+    "pandas",
     "power_grid_model>=1.6.46",
     "pyyaml",
     "structlog",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ requires-python = ">=3.9"
 dependencies = [
     "numpy>=1.20",
     "openpyxl",
-    "pandas",
+    "pandas<3.0",
     "power_grid_model>=1.6.46",
     "pyyaml",
     "structlog",

--- a/src/power_grid_model_io/converters/pandapower_converter.py
+++ b/src/power_grid_model_io/converters/pandapower_converter.py
@@ -21,6 +21,7 @@ from power_grid_model_io.utils.parsing import is_node_ref, parse_trafo3_connecti
 
 PandaPowerData = MutableMapping[str, pd.DataFrame]
 
+pd.set_option('future.no_silent_downcasting', True)
 logger = structlog.get_logger(__file__)
 
 
@@ -728,7 +729,7 @@ class PandaPowerConverter(BaseConverter[PandaPowerData]):
         no_vector_groups = np.isnan(winding_types["winding_from"]) | np.isnan(winding_types["winding_to"])
         no_vector_groups_dyn = no_vector_groups & (clocks % 2)
         winding_types[no_vector_groups] = WindingType.wye_n
-        winding_types["winding_from"][no_vector_groups_dyn] = WindingType.delta
+        winding_types.loc[no_vector_groups_dyn, "winding_from"] = WindingType.delta
 
         # Create PGM array
         pgm_transformers = initialize_array(data_type="input", component_type="transformer", shape=len(pp_trafo))
@@ -838,8 +839,8 @@ class PandaPowerConverter(BaseConverter[PandaPowerData]):
         no_vector_groups_ynd2 = no_vector_groups & (clocks_12 % 2)
         no_vector_groups_ynd3 = no_vector_groups & (clocks_13 % 2)
         winding_types[no_vector_groups] = WindingType.wye_n
-        winding_types["winding_2"][no_vector_groups_ynd2] = WindingType.delta
-        winding_types["winding_3"][no_vector_groups_ynd3] = WindingType.delta
+        winding_types.loc[no_vector_groups_ynd2, "winding_2"] = WindingType.delta
+        winding_types.loc[no_vector_groups_ynd3, "winding_3"] = WindingType.delta
 
         pgm_3wtransformers = initialize_array(
             data_type="input", component_type="three_winding_transformer", shape=len(pp_trafo3w)


### PR DESCRIPTION
The problem relates to the Pandas library future warnings. To properly address the issue, we need to migrate current code take advantage of new calls before Pandas officially deprecates the problematic calls.

[Details]
The following 2 type of future warnings are given (and suppressed):
 - ChainedAssignmentError: behaviour will change in pandas 3.0
 - Downcasting object `dtype` arrays on `.fillna`, `.ffill`, `.bfill` is deprecated and will change in a future version.