### PR TITLE
do not fatally crash on pandas 2.1

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,4 +4,7 @@
 
 import pandas as pd
 
-pd.set_option("future.no_silent_downcasting", True)
+try:
+    pd.set_option("future.no_silent_downcasting", True)
+except pd.errors.OptionError:
+    pass

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -4,5 +4,8 @@
 
 import pandas as pd
 
-# TODO(mgovers) We're ready for Pandas 3.x, but pandapower is not. Move to parent conftest when it is.
-pd.set_option("mode.copy_on_write", True)
+try:
+    # TODO(mgovers) We're ready for Pandas 3.x, but pandapower is not. Move to parent conftest when it is.
+    pd.set_option("mode.copy_on_write", True)
+except pd.errors.OptionError:
+    pass

--- a/tests/validation/conftest.py
+++ b/tests/validation/conftest.py
@@ -4,7 +4,13 @@
 
 import pandas as pd
 
-pd.set_option("future.no_silent_downcasting", True)
+try:
+    pd.set_option("future.no_silent_downcasting", True)
+except pd.errors.OptionError:
+    pass
 
-# TODO(mgovers) We're ready for Pandas 3.x, but pandapower is not. Move to parent conftest when it is.
-pd.set_option("mode.copy_on_write", False)
+try:
+    # TODO(mgovers) We're ready for Pandas 3.x, but pandapower is not. Move to parent conftest when it is.
+    pd.set_option("mode.copy_on_write", False)
+except pd.errors.OptionError:
+    pass


### PR DESCRIPTION
`set_option` apparently changed since the last time i worked with it 😬 it used to go silence mode but now it actually crashes