### PR TITLE
Fix the instance id issue when having multiple converter objects 

### DIFF
--- a/src/power_grid_model_io/converters/base_converter.py
+++ b/src/power_grid_model_io/converters/base_converter.py
@@ -30,7 +30,7 @@ class BaseConverter(Generic[T], ABC):
         """
         Initialize a logger
         """
-        self._logger = logging.getLogger(type(self).__name__)
+        self._logger = logging.getLogger(f"{__name__}_{id(self)}")
         self._logger.setLevel(log_level)
         self._log = structlog.wrap_logger(self._logger, wrapper_class=structlog.make_filtering_bound_logger(log_level))
         self._source = source


### PR DESCRIPTION
When multiple converter objects of same class exist, the log level are sharing the same underlying name because of the way it is initialized. The fix contains the correct initialization of the logger.