### PR TITLE
BUGFix/Bumped `reuse` version from 1 to 3

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@
 
 repos:
   - repo: https://github.com/fsfe/reuse-tool
-    rev: v1.0.0
+    rev: v3.0.1
     hooks:
       - id: reuse
   - repo: https://github.com/pycqa/isort


### PR DESCRIPTION
Bumped `reuse` version from 1 to 3

This is to officially support Python 3.12 development
