### PR TITLE
Remove needless rl logic.

### DIFF
--- a/.github/workflows/build-test-and-sonar.yml
+++ b/.github/workflows/build-test-and-sonar.yml
@@ -180,6 +180,6 @@ jobs:
           files: |
             ./wheelhouse/*
           tag_name: v${{ needs.build-python.outputs.version }}
-          prerelease: github.ref != "refs/heads/main"
+          prerelease: github.ref != 'refs/heads/main'
           generate_release_notes: true
           target_commitish: ${{ github.sha }}

--- a/.github/workflows/build-test-and-sonar.yml
+++ b/.github/workflows/build-test-and-sonar.yml
@@ -180,6 +180,6 @@ jobs:
           files: |
             ./wheelhouse/*
           tag_name: v${{ needs.build-python.outputs.version }}
-          prerelease: github.ref != 'refs/heads/main'
+          prerelease: ${{github.ref != 'refs/heads/main'}}
           generate_release_notes: true
           target_commitish: ${{ github.sha }}

--- a/.github/workflows/build-test-and-sonar.yml
+++ b/.github/workflows/build-test-and-sonar.yml
@@ -9,7 +9,6 @@ on:
   push:
     branches:
       - main
-      - 'release/**'
   # run pipeline on pull request
   pull_request:
   # Allows you to run this workflow manually from the Actions tab
@@ -18,7 +17,6 @@ on:
 jobs:
 
   build-python:
-    if: (github.event_name == 'push') || (github.event_name == 'workflow_dispatch') || !startsWith(github.head_ref,  'release')
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.version.outputs.version }}
@@ -49,8 +47,6 @@ jobs:
           path: wheelhouse/
 
   sonar-cloud:
-    # only run sonar server in push event or pull request event from own repo
-    if: (github.event_name == 'push') || (github.event_name == 'workflow_dispatch') || (!startsWith(github.head_ref, 'release') && (github.event.pull_request.head.repo.owner.login == 'PowerGridModel'))
     permissions:
       contents: write
     runs-on: ubuntu-latest
@@ -184,6 +180,6 @@ jobs:
           files: |
             ./wheelhouse/*
           tag_name: v${{ needs.build-python.outputs.version }}
-          prerelease: ${{ contains(needs.build-python.outputs.version, 'rc') || contains(needs.build-python.outputs.version, 'a') }}
+          prerelease: github.ref != "refs/heads/main"
           generate_release_notes: true
           target_commitish: ${{ github.sha }}

--- a/.github/workflows/citations.yml
+++ b/.github/workflows/citations.yml
@@ -5,11 +5,10 @@
 name: Validate citation
 
 on:
-  # run pipeline on push event of main or release branch, or when CITATIONS path has changed
+  # run pipeline on push event of main branch, or when CITATIONS path has changed
   push:
     branches:
       - main
-      - 'release/**'
     paths:
       - CITATION.cff
 

--- a/set_pypi_version.py
+++ b/set_pypi_version.py
@@ -32,12 +32,6 @@ def set_version(pkg_dir: Path):
             # major.minor.patch
             # do nothing
             pass
-        elif "release" in ref:
-            # release branch
-            # major.minor.patch rc 9 build_number short_hash
-            # NOTE: the major.minor in release branch is usually higher than the main branch
-            # this is the leading version if you enable test version in pip install
-            version += f"rc9{build_number}{short_hash}"
         else:
             # feature branch
             # major.minor.patch a 1 build_number short_hash


### PR DESCRIPTION
Branches with the 'release' string are not supported anymore. In this PR we remove the logic behind it.

Relates to #500 