### PR TITLE
add merge queue stuff for CI

### DIFF
--- a/.github/workflows/build-test-and-sonar.yml
+++ b/.github/workflows/build-test-and-sonar.yml
@@ -11,8 +11,16 @@ on:
       - main
   # run pipeline on pull request
   pull_request:
-  # Allows you to run this workflow manually from the Actions tab
+  # run pipeline on merge queue
+  merge_group:
+  # run this workflow manually from the Actions tab
   workflow_dispatch:
+    inputs:
+      create_release:
+        type: boolean
+        description: Create a (pre-)release when CI passes
+        default: true
+        required: true
 
 jobs:
 
@@ -167,14 +175,14 @@ jobs:
           path: wheelhouse/
 
       - name: Upload wheels
-        if: (github.event_name == 'push') || (github.event_name == 'workflow_dispatch')
+        if: (github.event_name == 'push') || ((github.event_name == 'workflow_dispatch') && (github.event.inputs.create_release == 'true'))
         run: |
           pip install twine
           echo "Publish to PyPI..."
           twine upload --verbose wheelhouse/*
 
       - name: Release
-        if: (github.event_name == 'push') || (github.event_name == 'workflow_dispatch')
+        if: (github.event_name == 'push') || ((github.event_name == 'workflow_dispatch') && (github.event.inputs.create_release == 'true'))
         uses: softprops/action-gh-release@v2
         with:
           files: |

--- a/.github/workflows/check-blocking-labels.yml
+++ b/.github/workflows/check-blocking-labels.yml
@@ -6,14 +6,17 @@
 name: Check Blocking Labels
 
 on:
-  workflow_dispatch:
+  # run pipeline on pull request
   pull_request:
-    branches:
     types:
       - opened
       - synchronize
       - labeled
       - unlabeled
+  # run pipeline on merge queue
+  merge_group:
+  # run this workflow manually from the Actions tab
+  workflow_dispatch:
 
 jobs:
   check-blocking-labels:

--- a/.github/workflows/check-code-quality.yml
+++ b/.github/workflows/check-code-quality.yml
@@ -11,8 +11,8 @@ on:
       - main
   # run pipeline on pull request
   pull_request:
-  # Allows you to run this workflow manually from the Actions tab
-  workflow_dispatch:
+  # run pipeline on merge queue
+  merge_group:
 
 jobs:
   check-code-quality:

--- a/.github/workflows/reuse-compliance.yml
+++ b/.github/workflows/reuse-compliance.yml
@@ -11,6 +11,8 @@ on:
       - main
   # run pipeline on pull request
   pull_request:
+  # run pipeline on merge queue
+  merge_group:
 
 jobs:
   reuse-compliance-check:


### PR DESCRIPTION
Part 1 of https://github.com/PowerGridModel/power-grid-model/issues/528

* Add `on: merge_group` to CI jobs
* Add option to not create a pre-release when running manually
  * [x] Run with creating pre-release in https://github.com/PowerGridModel/power-grid-model-io/actions/runs/8293342969 => created pre-release https://github.com/PowerGridModel/power-grid-model-io/releases/tag/v1.2.77a1122505453653
  * [ ] Run without creating pre-release in https://github.com/PowerGridModel/power-grid-model-io/actions/runs/8293463369 => no release created https://github.com/PowerGridModel/power-grid-model-io/actions/runs/8293463369/job/22697226011
  ![image](https://github.com/PowerGridModel/power-grid-model-io/assets/15234327/795b3cee-9d3d-4d30-acf6-08d4645dfe58)
