### PR TITLE
Implement measurement field conversion from Vision

### DIFF
--- a/src/power_grid_model_io/functions/_functions.py
+++ b/src/power_grid_model_io/functions/_functions.py
@@ -11,7 +11,7 @@ from typing import Any, Optional, TypeVar, cast
 import numpy as np
 import structlog
 from power_grid_model import WindingType
-
+from power_grid_model import MeasuredTerminalType
 T = TypeVar("T")
 
 _LOG = structlog.get_logger(__file__)
@@ -24,13 +24,27 @@ WINDING_TYPES = {
     "ZN": WindingType.zigzag_n,
 }
 
+MEASURED_TERMINAL_TYPE_MAP = {
+    "transformer_from": MeasuredTerminalType.branch_from,
+    "transformer_to": MeasuredTerminalType.branch_to,
+    "cable_from": MeasuredTerminalType.branch_from,
+    "cable_to": MeasuredTerminalType.branch_to,
+    "transformer_load_to": MeasuredTerminalType.branch_to,
+    "load_to": MeasuredTerminalType.branch_to,
+    "earthing_transformer_to": MeasuredTerminalType.branch_to,
+    "transformer3_1": MeasuredTerminalType.branch3_1,
+    "transformer3_2": MeasuredTerminalType.branch3_2,
+    "transformer3_3": MeasuredTerminalType.branch3_3,
+}
+ 
+
 
 def has_value(value: Any) -> bool:
     """
     Return True if the value is not None, NaN or empty string.
     """
     if value is None:
-        return False
+        return False 
     if isinstance(value, float):
         return not np.isnan(value)
     return value != ""
@@ -104,3 +118,21 @@ def both_zeros_to_nan(value: float, other_value: float) -> float:
         _LOG.warning("0 replaced to nan")
         return float("nan")
     return value
+
+def find_terminal_type(**kwargs) -> MeasuredTerminalType:
+    """
+    Return 'branch_from' if any argument contains 'from' in its name.
+    Return 'branch_to' if any argument contains 'to' in its name.
+    Return the name of the first argument that evaluates to True otherwise.
+
+    Parameters:
+    - args: Variable number of input values.
+
+    Returns:
+    - String representation based on the conditions mentioned above.
+    """ 
+    for key, id in kwargs.items():
+        if id is not None:
+            return MEASURED_TERMINAL_TYPE_MAP[key]
+    _LOG.warning("No proper measured terminal type is found!")
+    return float("nan")

--- a/src/power_grid_model_io/functions/_functions.py
+++ b/src/power_grid_model_io/functions/_functions.py
@@ -25,16 +25,27 @@ WINDING_TYPES = {
 }
 
 MEASURED_TERMINAL_TYPE_MAP = {
-    "transformer_from": MeasuredTerminalType.branch_from,
-    "transformer_to": MeasuredTerminalType.branch_to,
     "cable_from": MeasuredTerminalType.branch_from,
     "cable_to": MeasuredTerminalType.branch_to,
-    "transformer_load_to": MeasuredTerminalType.branch_to,
-    "load_to": MeasuredTerminalType.branch_to,
-    "earthing_transformer_to": MeasuredTerminalType.branch_to,
+    "line_from": MeasuredTerminalType.branch_from,
+    "line_to": MeasuredTerminalType.branch_to, 
+    "reactance_coil_from": MeasuredTerminalType.branch_from,
+    "reactance_coil_to": MeasuredTerminalType.branch_to,
+    "special_transformer_from": MeasuredTerminalType.branch_from,
+    "special_transformer_to": MeasuredTerminalType.branch_to,
+    "transformer_from": MeasuredTerminalType.branch_from,
+    "transformer_to": MeasuredTerminalType.branch_to,
+    "transformer_load": MeasuredTerminalType.branch_to,
+    "earthing_transformer": MeasuredTerminalType.branch_to,
     "transformer3_1": MeasuredTerminalType.branch3_1,
     "transformer3_2": MeasuredTerminalType.branch3_2,
     "transformer3_3": MeasuredTerminalType.branch3_3,
+    "source": MeasuredTerminalType.source,
+    "shunt_capacitor": MeasuredTerminalType.shunt,
+    "shunt_reactor": MeasuredTerminalType.shunt,
+    "pv": MeasuredTerminalType.generator,
+    "wind_turbine": MeasuredTerminalType.generator,
+    "load": MeasuredTerminalType.load,
 }
  
 
@@ -134,5 +145,5 @@ def find_terminal_type(**kwargs) -> MeasuredTerminalType:
     for key, id in kwargs.items():
         if id is not None:
             return MEASURED_TERMINAL_TYPE_MAP[key]
-    _LOG.warning("No proper measured terminal type is found!")
+    _LOG.warning("No measured terminal type is found!")
     return float("nan")

--- a/src/power_grid_model_io/utils/auto_id.py
+++ b/src/power_grid_model_io/utils/auto_id.py
@@ -119,4 +119,4 @@ class AutoID:
         Returns:
             The original item
         """
-        return self._items[idx]
+        return getattr(self._items[idx], None)

--- a/tests/data/vision/vision_9_7_en.yaml
+++ b/tests/data/vision/vision_9_7_en.yaml
@@ -1,0 +1,1153 @@
+# SPDX-FileCopyrightText: Contributors to the Power Grid Model project <powergridmodel@lfenergy.org>
+#
+# SPDX-License-Identifier: MPL-2.0
+---
+id_reference:
+  nodes_table: Nodes
+  number: Number
+  node_number: Node.Number
+  sub_number: Subnumber
+grid:
+  Nodes:
+    node:
+      id:
+        auto_id:
+          key: Number
+      u_rated: Unom
+      extra:
+        - ID
+        - Name
+  Cables:
+    line:
+      id:
+        auto_id:
+          key: Number
+      from_node:
+        auto_id:
+          table: Nodes
+          key:
+            Number: From.Number
+      from_status: From.Switch state
+      to_node:
+        auto_id:
+          table: Nodes
+          key:
+            Number: To.Number
+      to_status: To.Switch state
+      r1: R
+      x1: X
+      c1: C
+      tan1: 0
+      r0:
+        power_grid_model_io.functions.both_zeros_to_nan:
+          value: R0
+          other_value: X0
+      x0:
+        power_grid_model_io.functions.both_zeros_to_nan:
+          value: X0
+          other_value: R0
+      c0: C0
+      tan0: 0
+      i_n: Inom'
+      extra:
+        - ID
+        - Name
+  Lines:
+    line:
+      id:
+        auto_id:
+          key: Number
+      from_node:
+        auto_id:
+          table: Nodes
+          key:
+            Number: From.Number
+      from_status: From.Switch state
+      to_node:
+        auto_id:
+          table: Nodes
+          key:
+            Number: To.Number
+      to_status: To.Switch state
+      r1: R
+      x1: X
+      c1: C
+      tan1: 0
+      r0:
+        power_grid_model_io.functions.both_zeros_to_nan:
+          value: R0
+          other_value: X0
+      x0:
+        power_grid_model_io.functions.both_zeros_to_nan:
+          value: X0
+          other_value: R0
+      c0: C0
+      tan0: 0
+      i_n: Inom'
+      extra:
+        - ID
+        - Name
+  Links:
+    link:
+      id:
+        auto_id:
+          key: Number
+      from_node:
+        auto_id:
+          table: Nodes
+          key:
+            Number: From.Number
+      from_status: From.Switch state
+      to_node:
+        auto_id:
+          table: Nodes
+          key:
+            Number: To.Number
+      to_status: To.Switch state
+      extra:
+        - ID
+        - Name
+  Reactance coils:
+    line:
+      id:
+        auto_id:
+          key: Number
+      from_node:
+        auto_id:
+          table: Nodes
+          key:
+            Number: From.Number
+      from_status: From.Switch state
+      to_node:
+        auto_id:
+          table: Nodes
+          key:
+            Number: To.Number
+      to_status: To.Switch state
+      r1: R
+      x1: X
+      c1: 0
+      tan1: 0
+      r0:
+        power_grid_model_io.functions.both_zeros_to_nan:
+          value: R0
+          other_value: X0
+      x0:
+        power_grid_model_io.functions.both_zeros_to_nan:
+          value: X0
+          other_value: R0
+      c0: 0
+      tan0: 0
+      i_n: Inom
+      extra:
+        - ID
+        - Name
+  Transformers:
+    transformer:
+      id:
+        auto_id:
+          key: Number
+      from_node:
+        auto_id:
+          table: Nodes
+          key:
+            Number: From.Number
+      from_status: From.Switch state
+      to_node:
+        auto_id:
+          table: Nodes
+          key:
+            Number: To.Number
+      to_status: To.Switch state
+      u1: Unom1
+      u2: Unom2
+      sn: Snom
+      uk:
+        max:
+          - divide:
+              - Pk
+              - Snom
+          - power_grid_model_io.functions.value_or_default:
+              value: uk
+              default: 0.001
+          - 0.001
+      pk: Pk
+      i0:
+        power_grid_model_io.functions.phase_to_phase.relative_no_load_current:
+          i_0: Io
+          p_0: Po
+          s_nom: Snom
+          u_nom: Unom2
+      p0: Po
+      winding_from:
+        power_grid_model_io.functions.phase_to_phase.get_winding_from:
+          conn_str: Connection
+          neutral_grounding: N1
+      winding_to:
+        power_grid_model_io.functions.phase_to_phase.get_winding_to:
+          conn_str: Connection
+          neutral_grounding: N2
+      clock:
+        power_grid_model_io.functions.phase_to_phase.get_clock:
+          conn_str: Connection
+      tap_side: Tap side
+      tap_pos: Tap
+      tap_min: Tap min
+      tap_max: Tap max
+      tap_nom: Tap nom
+      tap_size: Tap size
+      uk_min:
+        max:
+          - divide:
+              - Pk
+              - Snom
+          - power_grid_model_io.functions.value_or_default:
+              value: uk
+              default: 0.001
+          - 0.001
+      uk_max:
+        max:
+          - divide:
+              - Pk
+              - Snom
+          - power_grid_model_io.functions.value_or_default:
+              value: uk
+              default: 0.001
+          - 0.001
+      pk_min: Pk
+      pk_max: Pk
+      r_grounding_from: Re1
+      x_grounding_from: Xe1
+      r_grounding_to: Re2
+      x_grounding_to: Xe2
+      extra:
+        - ID
+        - Name
+  Special transformers:
+    transformer:
+      id:
+        auto_id:
+          key: Number
+      from_node:
+        auto_id:
+          table: Nodes
+          key:
+            Number: From.Number
+      from_status: From.Switch state
+      to_node:
+        auto_id:
+          table: Nodes
+          key:
+            Number: To.Number
+      to_status: To.Switch state
+      u1: Unom1
+      u2: Unom2
+      sn: Snom
+      uk:
+        max:
+          - divide:
+              - Pknom
+              - Snom
+          - power_grid_model_io.functions.value_or_default:
+              value: uknom
+              default: 0.001
+          - 0.001
+      pk: Pknom
+      i0:
+        power_grid_model_io.functions.phase_to_phase.relative_no_load_current:
+          i_0: Io
+          p_0: Po
+          s_nom: Snom
+          u_nom: Unom2
+      p0: Po
+      winding_from: 0
+      winding_to: 0
+      clock: 0
+      tap_side: Tap side
+      tap_pos: Tap
+      tap_min: Tap min
+      tap_max: Tap max
+      tap_nom: Tap nom
+      tap_size: Tap size
+      uk_min:
+        max:
+          - divide:
+              - Pkmin
+              - Snom
+          - power_grid_model_io.functions.value_or_default:
+              value: ukmin
+              default: 0.001
+          - 0.001
+      uk_max:
+        max:
+          - divide:
+              - Pkmax
+              - Snom
+          - power_grid_model_io.functions.value_or_default:
+              value: ukmax
+              default: 0.001
+          - 0.001
+      pk_min: Pkmin
+      pk_max: Pkmax
+      r_grounding_from: 0
+      x_grounding_from: 0
+      r_grounding_to: 0
+      x_grounding_to: 0
+      extra:
+        - ID
+        - Name
+  Transformer loads:
+    transformer:
+      id:
+        auto_id:
+          name: transformer
+          key:
+            - Node.Number
+            - Subnumber
+      from_node:
+        auto_id:
+          table: Nodes
+          key:
+            Number: Node.Number
+      to_node:
+        auto_id:
+          name: internal_node
+          key:
+            - Node.Number
+            - Subnumber
+      from_status: Switch state
+      to_status: 1
+      u1: Unom1
+      u2: Unom2
+      sn: Snom
+      uk:
+        max:
+          - divide:
+              - Pk
+              - Snom
+          - power_grid_model_io.functions.value_or_default:
+              value: uk
+              default: 0.001
+          - 0.001
+      pk: Pk
+      p0: Po
+      i0:
+        power_grid_model_io.functions.phase_to_phase.relative_no_load_current:
+          i_0: 0
+          p_0: Po
+          s_nom: Snom
+          u_nom: Unom2
+      winding_from:
+        power_grid_model_io.functions.phase_to_phase.get_winding_from:
+          conn_str: Connection
+      winding_to:
+        power_grid_model_io.functions.phase_to_phase.get_winding_to:
+          conn_str: Connection
+      clock:
+        power_grid_model_io.functions.phase_to_phase.get_clock:
+          conn_str: Connection
+      tap_side: Tap side
+      tap_pos: Tap
+      tap_min: Tap min
+      tap_max: Tap max
+      tap_nom: Tap nom
+      tap_size: Tap size
+      uk_min:
+        max:
+          - divide:
+              - Pk
+              - Snom
+          - power_grid_model_io.functions.value_or_default:
+              value: uk
+              default: 0.001
+          - 0.001
+      uk_max:
+        max:
+          - divide:
+              - Pk
+              - Snom
+          - power_grid_model_io.functions.value_or_default:
+              value: uk
+              default: 0.001
+          - 0.001
+      pk_min: Pk
+      pk_max: Pk
+      r_grounding_from: 0
+      x_grounding_from: 0
+      r_grounding_to: 0
+      x_grounding_to: 0
+      extra:
+        - ID
+        - Name
+    node:
+      id:
+        auto_id:
+          name: internal_node
+          key:
+            - Node.Number
+            - Subnumber
+      u_rated: Unom2
+      extra:
+        - ID
+        - Name
+    sym_load:
+      id:
+        auto_id:
+          name: load
+          key:
+            - Node.Number
+            - Subnumber
+      node:
+        auto_id:
+          name: internal_node
+          key:
+            - Node.Number
+            - Subnumber
+      status: Switch state
+      type: Behaviour
+      p_specified:
+        multiply:
+          - Load.P
+          - reference:
+              query_column: Node.Number
+              other_table: Nodes
+              key_column: Number
+              value_column: Simultaneity
+      q_specified:
+        multiply:
+          - Load.Q
+          - reference:
+              query_column: Node.Number
+              other_table: Nodes
+              key_column: Number
+              value_column: Simultaneity
+      extra:
+        - ID
+        - Name
+    sym_gen:
+      - id:
+          auto_id:
+            name: generation
+            key:
+              - Node.Number
+              - Subnumber
+        node:
+          auto_id:
+            name: internal_node
+            key:
+              - Node.Number
+              - Subnumber
+        status: Switch state
+        type: 0
+        p_specified: Generation.P
+        q_specified: Generation.Q
+        extra:
+          - ID
+          - Name
+      - id:
+          auto_id:
+            name: pv_generation
+            key:
+              - Node.Number
+              - Subnumber
+        node:
+          auto_id:
+            name: internal_node
+            key:
+              - Node.Number
+              - Subnumber
+        status: Switch state
+        type: 0
+        p_specified: PV.Pnom
+        q_specified:
+          power_grid_model_io.functions.phase_to_phase.reactive_power:
+            p: PV.Pnom
+            cos_phi: 1
+        extra:
+          - ID
+          - Name
+  Sources:
+    source:
+      id:
+        auto_id:
+          key:
+            - Node.Number
+            - Subnumber
+      node:
+        auto_id:
+          table: Nodes
+          key:
+            Number: Node.Number
+      status: Switch state
+      u_ref: Uref
+      sk: Sk"nom
+      rx_ratio: R/X
+      z01_ratio: Z0/Z1
+      extra:
+        - ID
+        - Name
+  Synchronous generators:
+    sym_gen:
+      id:
+        auto_id:
+          key:
+            - Node.Number
+            - Subnumber
+      node:
+        auto_id:
+          table: Nodes
+          key:
+            Number: Node.Number
+      status: Switch state
+      type: 0
+      p_specified: Pref
+      q_specified:
+        multiply:
+          - power_grid_model_io.functions.phase_to_phase.reactive_power:
+              p: Pref
+              cos_phi: cos phi
+          - Q
+      extra:
+        - ID
+        - Name
+  Wind turbines:
+    sym_gen:
+      id:
+        auto_id:
+          key:
+            - Node.Number
+            - Subnumber
+      node:
+        auto_id:
+          table: Nodes
+          key:
+            Number: Node.Number
+      status: Switch state
+      type: 0
+      p_specified:
+        power_grid_model_io.functions.value_or_default:
+          value: Pref
+          default:
+            power_grid_model_io.functions.phase_to_phase.power_wind_speed:
+              p_nom: Pnom
+              wind_speed: Wind speed
+      q_specified:
+        power_grid_model_io.functions.phase_to_phase.reactive_power:
+          p:
+            power_grid_model_io.functions.value_or_default:
+              value: Pref
+              default:
+                power_grid_model_io.functions.phase_to_phase.power_wind_speed:
+                  p_nom: Pnom
+                  wind_speed: Wind speed
+          cos_phi: cos phi
+      extra:
+        - ID
+        - Name
+  Loads:
+    sym_load:
+      id:
+        auto_id:
+          key:
+            - Node.Number
+            - Subnumber
+      node:
+        auto_id:
+          table: Nodes
+          key:
+            Number: Node.Number
+      status: Switch state
+      type: Behaviour
+      p_specified:
+        multiply:
+          - P
+          - reference:
+              query_column: Node.Number
+              other_table: Nodes
+              key_column: Number
+              value_column: Simultaneity
+      q_specified:
+        multiply:
+          - Q
+          - reference:
+              query_column: Node.Number
+              other_table: Nodes
+              key_column: Number
+              value_column: Simultaneity
+      extra:
+        - ID
+        - Name
+  Zigzag transformers:
+    shunt:
+      id:
+        auto_id:
+          key:
+            - Node.Number
+            - Subnumber
+      node:
+        auto_id:
+          table: Nodes
+          key:
+            Number: Node.Number
+      status: Switch state
+      g1: 0
+      b1: 0
+      g0:
+        power_grid_model_io.functions.complex_inverse_real_part:
+          real: R0
+          imag: X0
+      b0:
+        power_grid_model_io.functions.complex_inverse_imaginary_part:
+          real: R0
+          imag: X0
+      extra:
+        - ID
+        - Name
+  Capacitors:
+    shunt:
+      id:
+        auto_id:
+          key:
+            - Node.Number
+            - Subnumber
+      node:
+        auto_id:
+          table: Nodes
+          key:
+            Number: Node.Number
+      status: Switch state
+      g1: 0
+      b1:
+        power_grid_model_io.functions.phase_to_phase.reactive_power_to_susceptance:
+          q: Q
+          u_nom: Unom
+      g0: 0
+      b0: 0
+      extra:
+        - ID
+        - Name
+  Reactors:
+    shunt:
+      id:
+        auto_id:
+          key:
+            - Node.Number
+            - Subnumber
+      node:
+        auto_id:
+          table: Nodes
+          key:
+            Number: Node.Number
+      status: Switch state
+      g1: 0
+      b1:
+        multiply:
+          - power_grid_model_io.functions.phase_to_phase.reactive_power_to_susceptance:
+              q: Q
+              u_nom: Unom
+          - -1
+      g0: 0
+      b0: 0
+      extra:
+        - ID
+        - Name
+  Pvs:
+    sym_gen:
+      id:
+        auto_id:
+          key:
+            - Node.Number
+            - Subnumber
+      node:
+        auto_id:
+          table: Nodes
+          key:
+            Number: Node.Number
+      status: Switch state
+      type: 0
+      p_specified:
+        power_grid_model_io.functions.phase_to_phase.pvs_power_adjustment:
+          p:
+            multiply:
+              - min:
+                - Pnom
+                - Inverter.Pnom | Inverter.Snom
+              - Scaling
+          efficiency_type: Inverter.efficiency type
+      q_specified:
+        multiply:
+          - power_grid_model_io.functions.phase_to_phase.reactive_power:
+              p:
+                min:
+                  - Pnom
+                  - Inverter.Pnom | Inverter.Snom
+              cos_phi: Inverter.cos phi
+          - Scaling
+      extra:
+        - ID
+        - Name
+  Three winding transformers:
+    three_winding_transformer:
+      id:
+        auto_id:
+          key: Number
+      node_1:
+        auto_id:
+          table: Nodes
+          key:
+            Number: Node1.Number
+      status_1: Switch state 1
+      node_2:
+        auto_id:
+          table: Nodes
+          key:
+            Number: Node2.Number
+      status_2: Switch state 2
+      node_3:
+        auto_id:
+          table: Nodes
+          key:
+            Number: Node3.Number
+      status_3: Switch state 3
+      u1: Unom1
+      u2: Unom2
+      u3: Unom3
+      sn_1: Snom1
+      sn_2: Snom2
+      sn_3: Snom3
+      uk_12:
+        max:
+          - divide:
+              - Pk12
+              - min:
+                  - Snom1
+                  - Snom2
+          - power_grid_model_io.functions.value_or_default:
+              value: uk12
+              default: 0.001
+          - 0.001
+      uk_13:
+        max:
+          - divide:
+              - Pk13
+              - min:
+                  - Snom1
+                  - Snom3
+          - power_grid_model_io.functions.value_or_default:
+              value: uk13
+              default: 0.001
+          - 0.001
+      uk_23:
+        max:
+          - divide:
+              - Pk23
+              - min:
+                  - Snom2
+                  - Snom3
+          - power_grid_model_io.functions.value_or_default:
+              value: uk23
+              default: 0.001
+          - 0.001
+      pk_12: Pk12
+      pk_13: Pk13
+      pk_23: Pk23
+      i0:
+        power_grid_model_io.functions.phase_to_phase.relative_no_load_current:
+          i_0: Io
+          p_0: Po
+          s_nom: Snom3
+          u_nom: Unom3
+      p0: Po
+      winding_1:
+        power_grid_model_io.functions.phase_to_phase.get_winding_1:
+          conn_str: Connection
+          neutral_grounding: N1
+      winding_2:
+        power_grid_model_io.functions.phase_to_phase.get_winding_2:
+          conn_str: Connection
+          neutral_grounding: N2
+      winding_3:
+        power_grid_model_io.functions.phase_to_phase.get_winding_2:
+          conn_str: Connection
+          neutral_grounding: N3
+      clock_12:
+        power_grid_model_io.functions.phase_to_phase.get_clock_12:
+          conn_str: Connection
+      clock_13:
+        power_grid_model_io.functions.phase_to_phase.get_clock_13:
+          conn_str: Connection
+      tap_side: Tap side a
+      tap_pos: Tap a
+      tap_min: Tap min a
+      tap_max: Tap max a
+      tap_nom: Tap nom a
+      tap_size: Tap size a
+      r_grounding_1: Re1
+      x_grounding_1: Xe1
+      r_grounding_2: Re2
+      x_grounding_2: Xe2
+      r_grounding_3: Re3
+      x_grounding_3: Xe3
+      extra:
+        - ID
+        - Name
+  Measure fields:        
+    sym_voltage_sensor:
+      id:
+        auto_id:
+          key: Number
+      measured_object:
+        auto_id:
+          table: Nodes
+            GUID: InObject.Number
+      u_measured: nan
+      u_angle_measured: nan
+      u_sigma: nan
+      filter:
+        - power_grid_model_io.functions.filter_if_empty:
+          - power_1
+        - power_grid_model_io.functions.filter_if_link:
+          - InObject.Sort
+      extra:
+        - ID
+        - Name
+    sym_power_sensor:
+      id:
+        auto_id:
+          key: Number
+      measured_object:
+        auto_id:
+          table: Nodes
+            GUID: InObject.Number
+      measured_terminal_type:
+        - power_grid_model_io.functions.find_terminal_type:
+          cable_from:
+            auto_id:
+              table: Cables
+              key:
+                From.Number: NearToNode.Number
+          cable_to:
+            auto_id:
+              table: Cables
+              key:
+                To.Number: NearToNode.Number
+          line_from:
+            auto_id:
+              table: Lines
+              key:
+                From.Number: NearToNode.Number
+          line_to:
+            auto_id:
+              table: Lines
+              key:
+                To.Number: NearToNode.Number
+          reactance_coil_from:
+            auto_id:
+              table: Reactance coils
+              key:
+                From.Number: NearToNode.Number
+          reactance_coil_to:
+            auto_id:
+              table: Reactance coils
+              key:
+                To.Number: NearToNode.Number
+          special_transformer_from:
+            auto_id:
+              table: Special transformers
+              key:
+                From.Number: NearToNode.Number
+          special_transformer_to:
+            auto_id:
+              table: Special transformers
+              key:
+                To.Number: NearToNode.Number
+          transformer_from:
+            auto_id:
+              table: Transformers
+              key:
+                From.Number: NearToNode.Number
+          transformer_to:
+            auto_id:
+              table: Transformers
+              key:
+                To.Number: NearToNode.Number
+          transformer_load:
+            auto_id:
+              table: Transformer loads
+              key:
+                Node.Number: NearToNode.Number
+          earthing_transformer:
+            auto_id:
+              table: Earthing transformers
+              key:
+                Node.Number: NearToNode.Number
+          transformer3_1:
+            auto_id:
+              table: Three winding transformers
+              key:
+                Node1.Number: NearToNode.Number
+          transformer3_2:
+            auto_id:
+              table: Three winding transformers
+              key:
+                Node2.Number: NearToNode.Number
+          transformer3_3:
+            auto_id:
+              table: Three winding transformers
+              key:
+                Node3.Number: NearToNode.Number
+          source:
+            auto_id:
+              table: Sources
+              key:
+                Node.Number: NearToNode.Number  
+          shunt_capacitor:
+            auto_id:
+              table: Shunt capacitors
+              key:
+                Node.Number: NearToNode.Number  
+          shunt_reactor:
+            auto_id:
+              table: Shunt reactors
+              key:
+                Node.Number: NearToNode.Number  
+          pv:
+            auto_id:
+              table: Pvs
+              key:
+                Node.Number: NearToNode.Number  
+          wind_turbine:
+            auto_id:
+              table: Wind turbines
+              key:
+                Node.Number: NearToNode.Number   
+          load:
+            auto_id:
+              table: Loads
+              key:
+                Node.Number: NearToNode.Number        
+      p_measured: nan
+      q_measured: nan
+      p_sigma: nan
+      q_sigma: nan
+      filter:
+        - power_grid_model_io.functions.filter_if_empty:
+          - power_2
+        - power_grid_model_io.functions.filter_if_link:
+          - InObject.Sort
+      extra:
+        - ID
+        - Name
+    sym_power_sensor:
+      id:
+        auto_id:
+          key: Number
+      measured_object:
+        auto_id:
+          table: Nodes
+            GUID: InObject.Number
+      measured_terminal_type:
+        - power_grid_model_io.functions.find_terminal_type:
+          cable_from:
+            auto_id:
+              table: Cables
+              key:
+                From.Number: NearToNode.Number
+          cable_to:
+            auto_id:
+              table: Cables
+              key:
+                To.Number: NearToNode.Number
+          transformer_from:
+            auto_id:
+              table: Transformers
+              key:
+                From.Number: NearToNode.Number
+          transformer_to:
+            auto_id:
+              table: Transformers
+              key:
+                To.Number: NearToNode.Number
+          transformer_load_to:
+            auto_id:
+              table: Transformer loads
+              key:
+                Node.Number: NearToNode.Number
+          load_to:
+            auto_id:
+              table: Loads
+              key:
+                Node.Number: NearToNode.Number
+          earthing_transformer_to:
+            auto_id:
+              table: Earthing transformers loads
+              key:
+                Node.Number: NearToNode.Number
+          transformer3_1:
+            auto_id:
+              table: Three winding transformers
+              key:
+                Node1.Number: NearToNode.Number
+          transformer3_2:
+            auto_id:
+              table: Three winding transformers
+              key:
+                Node2.Number: NearToNode.Number
+          transformer3_3:
+            auto_id:
+              table: Three winding transformers
+              key:
+                Node3.Number: NearToNode.Number          
+      p_measured: nan
+      q_measured: nan
+      p_sigma: nan
+      q_sigma: nan
+      filter:
+        - power_grid_model_io.functions.filter_if_empty:
+          - power_3
+        - power_grid_model_io.functions.filter_if_link:
+          - InObject.Sort
+      extra:
+        - ID
+        - Name
+    sym_power_sensor:
+      id:
+        auto_id:
+          key: Number
+      measured_object:
+        auto_id:
+          table: Nodes
+            GUID: InObject.Number
+      measured_terminal_type:
+        - power_grid_model_io.functions.find_terminal_type:
+          cable_from:
+            auto_id:
+              table: Cables
+              key:
+                From.Number: NearToNode.Number
+          cable_to:
+            auto_id:
+              table: Cables
+              key:
+                To.Number: NearToNode.Number
+          transformer_from:
+            auto_id:
+              table: Transformers
+              key:
+                From.Number: NearToNode.Number
+          transformer_to:
+            auto_id:
+              table: Transformers
+              key:
+                To.Number: NearToNode.Number
+          transformer_load_to:
+            auto_id:
+              table: Transformer loads
+              key:
+                Node.Number: NearToNode.Number
+          load_to:
+            auto_id:
+              table: Loads
+              key:
+                Node.Number: NearToNode.Number
+          earthing_transformer_to:
+            auto_id:
+              table: Earthing transformers loads
+              key:
+                Node.Number: NearToNode.Number
+          transformer3_1:
+            auto_id:
+              table: Three winding transformers
+              key:
+                Node1.Number: NearToNode.Number
+          transformer3_2:
+            auto_id:
+              table: Three winding transformers
+              key:
+                Node2.Number: NearToNode.Number
+          transformer3_3:
+            auto_id:
+              table: Three winding transformers
+              key:
+                Node3.Number: NearToNode.Number          
+      p_measured: nan
+      q_measured: nan
+      p_sigma: nan
+      q_sigma: nan
+      filter:
+        - power_grid_model_io.functions.filter_if_empty:
+          - power_4
+        - power_grid_model_io.functions.filter_if_link:
+          - InObject.Sort
+      extra:
+        - ID
+        - Name
+  
+units:
+  A: null
+  F:
+    µF: 0.000_001
+  V:
+    kV: 1_000.0
+  VA:
+    kVA: 1_000.0
+    MVA: 1_000_000.0
+  VAR:
+    kvar: 1_000.0
+    Mvar: 1_000_000.0
+  W:
+    kW: 1_000.0
+    MW: 1_000_000.0
+  Wp:
+    kWp: 1_000.0
+    MWp: 1_000_000.0
+  m/s: null
+  ohm:
+    Ohm: 1.0
+  ohm/m:
+    ohm/km: 0.001
+  one:
+    pu: 1.0
+    "%": 0.01
+    "‰": 0.001
+
+substitutions:
+  ".*Switch state":
+    "off": 0
+    "in": 1
+    "on": 1
+  "Switch state .*":
+    "off": 0
+    "in": 1
+    "on": 1
+  N1:
+    0: false
+    1: true
+    none: false
+    own: true
+  N2:
+    0: false
+    1: true
+    none: false
+    own: true
+  N3:
+    0: false
+    1: true
+    none: false
+    own: true
+  Behaviour:
+    Constant admittance: 1
+    Constant impedance: 1
+    ~Constant current: 2
+    Constant power: 0
+    Default: 0
+    Industry: 0
+    Business: 0
+    Residential: 0
+    Living: 0
+  Tap side:
+    1: 0
+    2: 1
+  Synchronous generators.Q:
+    absorb: -1
+    supply: 1


### PR DESCRIPTION
only part of the code to determine the measured terminal type is finished. Further changes in the tabular converter is not implemented. Therefore pytest is still failed.