### PR TITLE
run citations workflow when current workflow changes + add concurrency check

### DIFF
--- a/.github/workflows/build-test-and-sonar.yml
+++ b/.github/workflows/build-test-and-sonar.yml
@@ -22,6 +22,10 @@ on:
         default: true
         required: true
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
 
   build-python:

--- a/.github/workflows/build-test-and-sonar.yml
+++ b/.github/workflows/build-test-and-sonar.yml
@@ -98,6 +98,9 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python: ["3.9", "3.10", "3.11", "3.12"]
+        exclude:
+          - os: macos-latest
+            python: "3.9"
       fail-fast: false
     runs-on: ${{ matrix.os }}
 
@@ -129,6 +132,9 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python: ["3.9", "3.10", "3.11", "3.12"]
+        exclude:
+          - os: macos-latest
+            python: "3.9"
       fail-fast: false
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/check-blocking-labels.yml
+++ b/.github/workflows/check-blocking-labels.yml
@@ -18,6 +18,10 @@ on:
   # run this workflow manually from the Actions tab
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check-blocking-labels:
     runs-on: ubuntu-latest

--- a/.github/workflows/check-code-quality.yml
+++ b/.github/workflows/check-code-quality.yml
@@ -14,6 +14,10 @@ on:
   # run pipeline on merge queue
   merge_group:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check-code-quality:
     runs-on: ubuntu-latest

--- a/.github/workflows/citations.yml
+++ b/.github/workflows/citations.yml
@@ -9,6 +9,9 @@ on:
   push:
     branches:
       - main
+    paths:
+      - CITATION.cff
+      - .github/workflows/citations.yml
 
   pull_request:
     paths:

--- a/.github/workflows/citations.yml
+++ b/.github/workflows/citations.yml
@@ -9,10 +9,17 @@ on:
   push:
     branches:
       - main
+
+  pull_request:
     paths:
       - CITATION.cff
+      - .github/workflows/citations.yml
 
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   validate-citations:

--- a/.github/workflows/reuse-compliance.yml
+++ b/.github/workflows/reuse-compliance.yml
@@ -14,6 +14,10 @@ on:
   # run pipeline on merge queue
   merge_group:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   reuse-compliance-check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
When https://github.com/PowerGridModel/power-grid-model/pull/571 and https://github.com/PowerGridModel/power-grid-model-io/pull/244 happened, we needed to manually run the citations validation check. This adds that and thereby also provides a template for similar actions that only need to happen when certain files change.

Proof that this change works: https://github.com/PowerGridModel/power-grid-model-io/actions/runs/8817491150/job/24203988223?pr=246

In addition, this action introduces the same github actions concurrency checks that the PGM repository has

We had to skip the `python3.9` run on `macos-latest` due to the failure in https://github.com/PowerGridModel/power-grid-model-io/actions/runs/8816931897/job/24202179419?pr=246 which reads
> Version 3.9 was not found in the local cache
> Error: The version '3.9' with architecture 'arm64' was not found for macOS 14.4.1.
> The list of all available versions can be found here: https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
