### PR TITLE
fix empty data auto id for tabular converter

### DIFF
--- a/src/power_grid_model_io/converters/tabular_converter.py
+++ b/src/power_grid_model_io/converters/tabular_converter.py
@@ -626,6 +626,8 @@ class TabularConverter(BaseConverter[TabularData]):
 
             return pgm_id
 
+        if col_data.empty:
+            return col_data
         return col_data.apply(auto_id, axis=1, raw=True)
 
     def _parse_pandas_function(

--- a/tests/unit/converters/test_tabular_converter.py
+++ b/tests/unit/converters/test_tabular_converter.py
@@ -798,6 +798,22 @@ def test_parse_auto_id__invalid_key_definition(
         )
 
 
+@patch("power_grid_model_io.converters.tabular_converter.TabularConverter._get_id")
+def test_parse_auto_id__empty_col_data(
+    mock_get_id: MagicMock, converter: TabularConverter, tabular_data_no_units_no_substitutions: TabularData
+):
+    converter._parse_auto_id(
+        data=tabular_data_no_units_no_substitutions,
+        table="lines",
+        ref_table=None,
+        ref_name=None,
+        key_col_def={"id": "id_number", "node": "from_node_side"},
+        table_mask=np.array([False, False]),
+        extra_info={},
+    )
+    mock_get_id.assert_not_called()
+
+
 @pytest.mark.parametrize(
     ("function", "expected"),
     [


### PR DESCRIPTION
### Changes proposed in this PR include:

An extra id was being generated. It occured only when no components were present after filtering. The cause was that even when an empty col_data was to be processed, the _get_id() function was getting called via the `.apply` function and an extra id was being generated.