### PR TITLE
Fix nightly build - citations

### DIFF
--- a/.github/workflows/citations.yml
+++ b/.github/workflows/citations.yml
@@ -31,5 +31,8 @@ jobs:
     steps:
     - name: checkout
       uses: actions/checkout@v4
+    - name: Install R
+      run: |
+        sudo apt-get update && sudo apt-get install -y r-base
     - name: Validate CITATION.cff
       uses: dieghernan/cff-validator@v3


### PR DESCRIPTION
The Citations action in the Nightly Build broke. This happened before when we upgraded PGM actions to Ubuntu 24.04 manually, so this may indicate that ubuntu-release is finally (possibly) migrated to 24.04.

The fix is to install R manually, since the Ubuntu 24.04 image provided by Github doesn't have R by default.

Don't merge until the [manual nightly build](https://github.com/PowerGridModel/power-grid-model-io/actions/runs/12598290027) passes successfully.
