### PR TITLE
fix winding config in yaml

### DIFF
--- a/src/power_grid_model_io/config/excel/vision_en.yaml
+++ b/src/power_grid_model_io/config/excel/vision_en.yaml
@@ -825,7 +825,7 @@ grid:
           conn_str: Connection
           neutral_grounding: N2
       winding_3:
-        power_grid_model_io.functions.phase_to_phase.get_winding_2:
+        power_grid_model_io.functions.phase_to_phase.get_winding_3:
           conn_str: Connection
           neutral_grounding: N3
       clock_12:

--- a/src/power_grid_model_io/config/excel/vision_en_9_7.yaml
+++ b/src/power_grid_model_io/config/excel/vision_en_9_7.yaml
@@ -820,7 +820,7 @@ grid:
           conn_str: Connection
           neutral_grounding: N2
       winding_3:
-        power_grid_model_io.functions.phase_to_phase.get_winding_2:
+        power_grid_model_io.functions.phase_to_phase.get_winding_3:
           conn_str: Connection
           neutral_grounding: N3
       clock_12:

--- a/src/power_grid_model_io/config/excel/vision_nl.yaml
+++ b/src/power_grid_model_io/config/excel/vision_nl.yaml
@@ -813,7 +813,7 @@ grid:
           conn_str: Schakeling
           neutral_grounding: N2
       winding_3:
-        power_grid_model_io.functions.phase_to_phase.get_winding_2:
+        power_grid_model_io.functions.phase_to_phase.get_winding_3:
           conn_str: Schakeling
           neutral_grounding: N3
       clock_12:


### PR DESCRIPTION
The config for winding_3 in default yaml is incorrectly set at winding_2 instead of winding_3.