### PR TITLE
Restrict pandapower to <3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers=[
 ]
 requires-python = ">=3.11"
 dependencies = [
-    "numpy>=1.20, <2.0",
+    "numpy>=1.20",
     "openpyxl",
     "pandas",
     "power_grid_model>=1.8",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers=[
 ]
 requires-python = ">=3.11"
 dependencies = [
-    "numpy>=1.20",
+    "numpy>=1.20, <2.0",
     "openpyxl",
     "pandas",
     "power_grid_model>=1.8",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dynamic = ["version"]
 
 [project.optional-dependencies]
 dev = [
-    "pandapower>2.11.1",
+    "pandapower>2.11.1, <3.0",
     "pre-commit",
     "pylint",
     "pytest",
@@ -50,7 +50,7 @@ dev = [
 ]
 examples = [
     "power-grid-model>1.9.80",
-    "pandapower>2.11.1",
+    "pandapower>2.11.1, <3.0",
     "pyarrow", # Pyarrow support for Python 3.12 scheduled for 14.0.0: https://github.com/apache/arrow/issues/37880
 ]
 doc = [

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -71,7 +71,6 @@ class MockFn:
     __slots__ = ["fn", "args", "kwargs", "postfix"]
 
     __array_struct__ = np.array([]).__array_struct__
-    __array_prepare__ = np.array([]).__array_prepare__
 
     def __init__(self, fn: str, *args, **kwargs):
         self.fn = fn

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -71,6 +71,7 @@ class MockFn:
     __slots__ = ["fn", "args", "kwargs", "postfix"]
 
     __array_struct__ = np.array([]).__array_struct__
+    __array_prepare__ = np.array([]).__array_prepare__
 
     def __init__(self, fn: str, *args, **kwargs):
         self.fn = fn


### PR DESCRIPTION
CI fails at #292 and #293 . We need to 
1) upgrade pandapower to 3.0 
2) remove the `__array_prepare__` from MockFn before upgrade to numpy 2.0 
