### PR TITLE
PGM-IO internal import resolution: Restrict version on PGM for internal import, Step 2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "numpy>=1.20",
     "openpyxl",
     "pandas",
-    "power_grid_model>=1.8",
+    "power_grid_model>=1.8, <1.11",
     "pyyaml",
     "structlog",
     "tqdm",


### PR DESCRIPTION
**Fixes issue**: https://github.com/PowerGridModel/power-grid-model-io/issues/297
Step 2 of "verbose robust resolution" mentioned in this issue solution.

Build fails as expected. Needs https://github.com/PowerGridModel/power-grid-model/pull/988