### PR TITLE
PGM-IO internal import resolution: Copy is_nan functionality from PGM, Step 4

### DIFF
--- a/src/power_grid_model_io/converters/pgm_json_converter.py
+++ b/src/power_grid_model_io/converters/pgm_json_converter.py
@@ -300,15 +300,15 @@ class PgmJsonConverter(BaseConverter[StructuredData]):
         """
         Determine if the data point is valid
         Args:
-            data: a single scaler or numpy array
+            data: a single scalar or numpy array
 
         Returns:
-            True if all the data points are invalid
+            True when all the data points are invalid
             False otherwise
         """
         nan_func = {
             np.dtype("f8"): lambda x: np.all(np.isnan(x)),
-            np.dtype("i4"): lambda x: np.all(x == np.iinfo("i4").min),
-            np.dtype("i1"): lambda x: np.all(x == np.iinfo("i1").min),
+            np.dtype("i4"): lambda x: np.all(x == np.iinfo(np.dtype("i4")).min),
+            np.dtype("i1"): lambda x: np.all(x == np.iinfo(np.dtype("i1")).min),
         }
         return bool(nan_func[data.dtype](data))

--- a/src/power_grid_model_io/converters/pgm_json_converter.py
+++ b/src/power_grid_model_io/converters/pgm_json_converter.py
@@ -21,6 +21,12 @@ from power_grid_model_io.data_stores.json_file_store import JsonFileStore
 from power_grid_model_io.data_types import ExtraInfo, StructuredData
 from power_grid_model_io.utils.dict import merge_dicts
 
+_NAN_FUNC = {
+    np.dtype("f8"): lambda x: np.all(np.isnan(x)),
+    np.dtype("i4"): lambda x: np.all(x == np.iinfo(np.dtype("i4")).min),
+    np.dtype("i1"): lambda x: np.all(x == np.iinfo(np.dtype("i1")).min),
+}
+
 
 class PgmJsonConverter(BaseConverter[StructuredData]):
     """
@@ -306,9 +312,4 @@ class PgmJsonConverter(BaseConverter[StructuredData]):
             True when all the data points are invalid
             False otherwise
         """
-        nan_func = {
-            np.dtype("f8"): lambda x: np.all(np.isnan(x)),
-            np.dtype("i4"): lambda x: np.all(x == np.iinfo(np.dtype("i4")).min),
-            np.dtype("i1"): lambda x: np.all(x == np.iinfo(np.dtype("i1")).min),
-        }
-        return bool(nan_func[data.dtype](data))
+        return bool(_NAN_FUNC[data.dtype](data))

--- a/src/power_grid_model_io/converters/pgm_json_converter.py
+++ b/src/power_grid_model_io/converters/pgm_json_converter.py
@@ -298,7 +298,7 @@ class PgmJsonConverter(BaseConverter[StructuredData]):
     @staticmethod
     def _is_nan(data: np.ndarray) -> bool:
         """
-        Determine if the data point is valid
+        Determine whether the data point is valid
         Args:
             data: a single scalar or numpy array
 

--- a/tests/unit/converters/test_pgm_json_converter.py
+++ b/tests/unit/converters/test_pgm_json_converter.py
@@ -155,3 +155,16 @@ def test_serialize_dataset(converter: PgmJsonConverter, pgm_input_data: SingleDa
     extra_info: ExtraInfo = {1: {"dummy": "data"}}
     structured_data_with_extra_info = converter._serialize_dataset(data=pgm_input_data, extra_info=extra_info)
     assert structured_data_with_extra_info == {"node": [{"id": 1, "dummy": "data"}, {"id": 2}]}
+
+
+def test_is_nan(converter: PgmJsonConverter):
+    single_value = np.array([np.nan])
+    assert converter._is_nan(single_value)
+    array_f8 = np.array([0.1, 0.2, np.nan], dtype=np.dtype("f8"))
+    assert not converter._is_nan(array_f8)
+    array_i4 = np.array([10, 2, -(2**31), 40], dtype=np.dtype("i4"))
+    assert not converter._is_nan(array_i4)
+    array_i1 = np.array([1, 0, -(2**7), 1], dtype=np.dtype("i1"))
+    assert not converter._is_nan(array_i1)
+    nan_array = np.array([np.nan, np.nan, np.nan])
+    assert converter._is_nan(nan_array)


### PR DESCRIPTION
**Fixes issue**: https://github.com/PowerGridModel/power-grid-model-io/issues/297

The alternative to Step 4, of copying the is_nan functionality is done. Since this is implemented, we can skip step 2
