### PR TITLE
Nightly fix: Update nightly for renaming

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   main:
-    uses: "./.github/workflows/build-test-and-sonar.yml"
+    uses: "./.github/workflows/ci.yml"
     permissions:
       contents: write
     with:


### PR DESCRIPTION
Nightly failed in  https://github.com/PowerGridModel/power-grid-model-io/actions/runs/14986900277/workflow

As per changes in https://github.com/PowerGridModel/power-grid-model-io/pull/296, the nightly file needs to be updated too.
Verify if this renaming is okay or not, since the above PR has additional contents regarding publishing at pypi.
