### PR TITLE
dependencies: dependabot for pip

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
This will tell us when pandapower releases 3.1.0, so that they will (theoretically) be python 3.13-compatible again, cfr. https://github.com/e2nIEE/pandapower/blob/develop/pyproject.toml#L40C4-L40C13