### PR TITLE
ci: enable python 3.13 tests by skipping pandapower stuffs

### DIFF
--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -111,7 +111,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python: ["3.11", "3.12"]
+        python: ["3.11", "3.12", "3.13"]
       fail-fast: false
     runs-on: ${{ matrix.os }}
 
@@ -131,8 +131,13 @@ jobs:
           name: power-grid-model-io
           path: wheelhouse/
 
-      - name: Install built wheel file
+      - name: Install built wheel file (Python 3.11 and 3.12)
+        if: matrix.python != '3.13'
         run: pip install power-grid-model-io[dev]==${{ needs.build-python.outputs.version }} --find-links=wheelhouse
+
+      - name: Install built wheel file (Python 3.13)
+        if: matrix.python == '3.13'
+        run: pip install power-grid-model-io[dev-bare]==${{ needs.build-python.outputs.version }} --find-links=wheelhouse
 
       - name: Unit test and coverage
         run: pytest --verbose
@@ -142,7 +147,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python: ["3.11", "3.12"]
+        python: ["3.11", "3.12", "3.13"]
       fail-fast: false
     runs-on: ${{ matrix.os }}
 
@@ -162,8 +167,13 @@ jobs:
           name: power-grid-model-io
           path: wheelhouse/
 
-      - name: Install built wheel file
+      - name: Install built wheel file (Python 3.11 and 3.12)
+        if: matrix.python != '3.13'
         run: pip install power-grid-model-io[dev]==${{ needs.build-python.outputs.version }} --find-links=wheelhouse
+
+      - name: Install built wheel file (Python 3.13)
+        if: matrix.python == '3.13'
+        run: pip install power-grid-model-io[dev-bare]==${{ needs.build-python.outputs.version }} --find-links=wheelhouse
 
       - name: Validation tests
         run: pytest tests/validation --no-cov --verbose

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,4 +36,4 @@ repos:
         language: system
         pass_filenames: false
         always_run: true
-        args: [ "--cov-fail-under=99" ]
+        args: [ "--cov-fail-under=98" ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,18 +39,20 @@ dependencies = [
 dynamic = ["version"]
 
 [project.optional-dependencies]
-dev = [
-    "pandapower>2.11.1",
+dev-bare = [  # pandapower 3.0.0 is not compatible with Python 3.13. pandapower 3.1 will be.
     "pre-commit",
     "pylint",
     "pytest",
     "pytest-cov",
     "pydantic>2", # Used in unit tests
-    "numba",
+]
+dev = [
+    "power-grid-model-io[dev-bare]",
+    "pandapower>2.11.1, <3.1", # pandapower 3.0.0 is not compatible with Python 3.13. pandapower 3.1 will be.
 ]
 examples = [
     "power-grid-model>1.9.80",
-    "pandapower>2.11.1, <3.0",
+    "pandapower>2.11.1, <3.0", # pandapower 3.0.0 has differences in results cfr. https://github.com/e2nIEE/pandapower/issues/2557
     "pyarrow", # Pyarrow support for Python 3.12 scheduled for 14.0.0: https://github.com/apache/arrow/issues/37880
 ]
 doc = [
@@ -86,7 +88,7 @@ addopts = [
     "--cov-report=term",
     "--cov-report=html:cov_html",
     "--cov-report=xml:python_coverage.xml",
-    "--cov-fail-under=98.5",
+    "--cov-fail-under=98.0",
 ]
 xfail_strict = true
 

--- a/src/power_grid_model_io/converters/pandapower_converter.py
+++ b/src/power_grid_model_io/converters/pandapower_converter.py
@@ -35,7 +35,7 @@ logger = structlog.get_logger(__file__)
 
 
 # pylint: disable=too-many-instance-attributes
-class PandaPowerConverter(BaseConverter[PandaPowerData]):
+class PandaPowerConverter(BaseConverter[PandaPowerData]):  # pragma: no cover
     """
     Panda Power Converter
     """

--- a/tests/unit/converters/test_pandapower_converter_input.py
+++ b/tests/unit/converters/test_pandapower_converter_input.py
@@ -3,19 +3,23 @@
 # SPDX-License-Identifier: MPL-2.0
 
 from importlib import metadata
-from typing import Callable
+from typing import Callable, TypeAlias
 from unittest.mock import ANY, MagicMock, call, patch
 
 import numpy as np
-import pandapower as pp
 import pandas as pd
 import pytest
 from packaging import version
 from power_grid_model import Branch3Side, BranchSide, LoadGenType, WindingType, initialize_array
 
+pp = pytest.importorskip("pandapower", reason="pandapower is not installed")
+# we add this to enable python 3.13 testing even though pandapower 3.0 is not yet compatible with it
+
 from power_grid_model_io.converters.pandapower_converter import PandaPowerConverter
 
 from ...utils import MockDf, MockFn, assert_struct_array_equal
+
+PandaPowerNet: TypeAlias = pp.pandapowerNet  # type: ignore
 
 
 def _generate_ids(*args, **kwargs):
@@ -624,7 +628,7 @@ def test_create_pgm_input_sources(mock_init_array: MagicMock, two_pp_objs, conve
 
 @pytest.mark.parametrize("kwargs", [{"r0x0_max": 0.5, "rx_max": 4}, {"x0x_max": 0.6}])
 def test_create_pgm_input_sources__zero_sequence(kwargs) -> None:
-    pp_net: pp.pandapowerNet = pp.create_empty_network()
+    pp_net: PandaPowerNet = pp.create_empty_network()
     pp.create_bus(net=pp_net, vn_kv=1.0)
     pp.create_ext_grid(pp_net, 0, **kwargs)
 
@@ -723,7 +727,7 @@ def test_create_pgm_input_asym_loads(mock_init_array: MagicMock, two_pp_objs, co
 
 def test_create_pgm_input_sym_loads__delta() -> None:
     # Arrange
-    pp_net: pp.pandapowerNet = pp.create_empty_network()
+    pp_net: PandaPowerNet = pp.create_empty_network()
     pp.create_bus(net=pp_net, vn_kv=0.0)
     pp.create_load(pp_net, 0, 0, type="delta")
 
@@ -739,7 +743,7 @@ def test_create_pgm_input_sym_loads__delta() -> None:
 
 def test_create_pgm_input_asym_loads__delta() -> None:
     # Arrange
-    pp_net: pp.pandapowerNet = pp.create_empty_network()
+    pp_net: PandaPowerNet = pp.create_empty_network()
     pp.create_bus(net=pp_net, vn_kv=0.0)
     pp.create_asymmetric_load(pp_net, 0, type="delta")
 
@@ -755,7 +759,7 @@ def test_create_pgm_input_asym_loads__delta() -> None:
 
 def test_create_pgm_input_transformers__tap_dependent_impedance() -> None:
     # Arrange
-    pp_net: pp.pandapowerNet = pp.create_empty_network()
+    pp_net: PandaPowerNet = pp.create_empty_network()
     pp.create_bus(net=pp_net, vn_kv=0.0)
     args = [0, 0, 0, 0, 0, 0, 0, 0, 0]
 
@@ -937,7 +941,7 @@ def test_create_pgm_input_transformers(mock_init_array: MagicMock, two_pp_objs, 
 )
 def test_create_pgm_input_transformers__default() -> None:
     # Arrange
-    pp_net: pp.pandapowerNet = pp.create_empty_network()
+    pp_net: PandaPowerNet = pp.create_empty_network()
     pp.create_bus(net=pp_net, vn_kv=0.0)
     args = [0, 0, 0, 0, 0, 0, 0, 0, 0]
     pp.create_transformer_from_parameters(
@@ -1066,7 +1070,7 @@ def test_create_pgm_input_sym_gens(mock_init_array: MagicMock, two_pp_objs, conv
 )
 def test_create_pgm_input_transformers__warnings(kwargs) -> None:
     # Arrange
-    pp_net: pp.pandapowerNet = pp.create_empty_network()
+    pp_net: PandaPowerNet = pp.create_empty_network()
     pp.create_bus(net=pp_net, vn_kv=0.0)
     args = [0, 0, 0, 0, 0, 0, 0, 0, 0]
     if "pfe_kw" in kwargs:
@@ -1291,7 +1295,7 @@ def test_create_pgm_input_three_winding_transformers(mock_init_array: MagicMock,
 )
 def test_create_pgm_input_transformers3w__default() -> None:
     # Arrange
-    pp_net: pp.pandapowerNet = pp.create_empty_network()
+    pp_net: PandaPowerNet = pp.create_empty_network()
     pp.create_bus(net=pp_net, vn_kv=0.0)
     args = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
     pp.create_transformer3w_from_parameters(
@@ -1432,7 +1436,7 @@ def test_create_pgm_input_transformers3w__default() -> None:
 )
 def test_create_pgm_input_transformers3w__warnings(kwargs) -> None:
     # Arrange
-    pp_net: pp.pandapowerNet = pp.create_empty_network()
+    pp_net: PandaPowerNet = pp.create_empty_network()
     pp.create_bus(net=pp_net, vn_kv=0.0)
     args = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
     if "pfe_kw" in kwargs:
@@ -1451,7 +1455,7 @@ def test_create_pgm_input_transformers3w__warnings(kwargs) -> None:
 
 def test_create_pgm_input_three_winding_transformers__tap_at_star_point() -> None:
     # Arrange
-    pp_net: pp.pandapowerNet = pp.create_empty_network()
+    pp_net: PandaPowerNet = pp.create_empty_network()
     pp.create_bus(net=pp_net, vn_kv=0.0)
     args = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
     pp.create_transformer3w_from_parameters(pp_net, *args, tap_at_star_point=True)
@@ -1466,7 +1470,7 @@ def test_create_pgm_input_three_winding_transformers__tap_at_star_point() -> Non
 
 def test_create_pgm_input_three_winding_transformers__tap_dependent_impedance() -> None:
     # Arrange
-    pp_net: pp.pandapowerNet = pp.create_empty_network()
+    pp_net: PandaPowerNet = pp.create_empty_network()
     pp.create_bus(net=pp_net, vn_kv=0.0)
     args = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
 
@@ -1590,7 +1594,7 @@ def test_create_pgm_input_wards__existing_loads() -> None:
     converter = PandaPowerConverter()
     # Arrange
 
-    pp_net: pp.pandapowerNet = pp.create_empty_network()
+    pp_net: PandaPowerNet = pp.create_empty_network()
     pp.create_bus(net=pp_net, vn_kv=0.0)
     pp.create_load(pp_net, 0, 0)
     pp.create_ward(pp_net, 0, 0, 0, 0, 0)
@@ -1692,7 +1696,7 @@ def test_create_pgm_input_motors__existing_loads() -> None:
     converter = PandaPowerConverter()
     # Arrange
 
-    pp_net: pp.pandapowerNet = pp.create_empty_network()
+    pp_net: PandaPowerNet = pp.create_empty_network()
     pp.create_bus(net=pp_net, vn_kv=0.0)
     pp.create_load(pp_net, 0, 0)
     pp.create_motor(pp_net, 0, 0, 0)

--- a/tests/validation/converters/test_pandapower_converter_input.py
+++ b/tests/validation/converters/test_pandapower_converter_input.py
@@ -15,6 +15,9 @@ from power_grid_model_io.converters import PandaPowerConverter
 from power_grid_model_io.data_types import ExtraInfo
 from power_grid_model_io.utils.json import JsonEncoder
 
+pp = pytest.importorskip("pandapower", reason="pandapower is not installed")
+# we add this to enable python 3.13 testing even though pandapower 3.0 is not yet compatible with it
+
 from ...data.pandapower.pp_validation import pp_net
 from ..utils import compare_extra_info, component_attributes, component_objects, load_json_single_dataset, select_values
 

--- a/tests/validation/converters/test_pandapower_converter_output.py
+++ b/tests/validation/converters/test_pandapower_converter_output.py
@@ -8,13 +8,15 @@ from functools import lru_cache
 from pathlib import Path
 from typing import Tuple
 
-import pandapower as pp
 import pandas as pd
 import pytest
 from power_grid_model.validation import assert_valid_input_data
 
 from power_grid_model_io.converters import PandaPowerConverter
 from power_grid_model_io.converters.pandapower_converter import PandaPowerData
+
+pp = pytest.importorskip("pandapower", reason="pandapower is not installed")
+# we add this to enable python 3.13 testing even though pandapower 3.0 is not yet compatible with it
 
 from ...data.pandapower.pp_validation import pp_net, pp_net_3ph
 from ..utils import component_attributes_df, load_json_single_dataset


### PR DESCRIPTION
Fixes #289 

pandapower is not compatible with a recent version of scipy and as a result not with python 3.13. We still want to test python 3.13, though. We decided to disable coverage for the pandapower converter for the time being (follow-up issue to be created) to reenable this. We also had to add a subset dependency group in the pyproject.toml that excludes pandapower while maintaining backwards compatibility.

@nitbharambe can you please review?

c.c. @TonyXiang8787 