### PR TITLE
Github release workflow fix: Rename job call

### DIFF
--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -6,13 +6,6 @@
 name: Build, Test, Sonar
 
 on:
-  push:
-    branches:
-      - main
-  # run pipeline on pull request
-  pull_request:
-  # run pipeline on merge queue
-  merge_group:
   # run pipeline from another workflow
   workflow_call:
     inputs:
@@ -207,7 +200,7 @@ jobs:
         run: echo "${{ steps.tag.outputs.tag }}"
 
       - name: Create GitHub release
-        if: (github.event_name == 'push') || ((github.event_name == 'workflow_dispatch') && (github.event.inputs.create_release == 'true'))
+        if: (inputs.create_release)
         uses: softprops/action-gh-release@v2
         with:
           files: |

--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 
-name: Build, Test, Sonar
+name: Build and Test
 
 on:
   # run pipeline from another workflow
@@ -63,41 +63,6 @@ jobs:
         with:
           name: power-grid-model-io
           path: wheelhouse/
-
-  sonar-cloud:
-    permissions:
-      contents: write
-    runs-on: ubuntu-latest
-    steps:
-
-      - name: Checkout source code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
-
-      - name: Setup Python 3.11
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-
-      - name: Install in develop mode
-        run: |
-          pip install -e .[dev]
-
-      - name: Test and Coverage
-        run: |
-          pytest
-
-          # Fix relative paths in coverage file
-          # Known bug: https://community.sonarsource.com/t/sonar-on-github-actions-with-python-coverage-source-issue/36057
-          sed -i 's@/home/runner/work/power-grid-model-io/power-grid-model-io@/github/workspace@g' python_coverage.xml
-
-      - name: SonarCloud Scan
-        if: ${{ (github.event_name == 'push') || (github.event.pull_request.head.repo.owner.login == 'PowerGridModel') }}
-        uses: SonarSource/sonarqube-scan-action@master
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
   unit-tests:
     needs: build-python
@@ -176,7 +141,6 @@ jobs:
       - build-python
       - unit-tests
       - validation-tests
-      - sonar-cloud
     permissions:
       contents: write
     runs-on: ubuntu-latest

--- a/.github/workflows/check-code-quality.yml
+++ b/.github/workflows/check-code-quality.yml
@@ -6,13 +6,6 @@
 name: Check Code Quality
 
 on:
-  push:
-    branches:
-      - main
-  # run pipeline on pull request
-  pull_request:
-  # run pipeline on merge queue
-  merge_group:
   # run pipeline from another workflow
   workflow_call:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ on:
         required: true
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-main
+  group: ${{ github.workflow }}-${{ github.ref }}-ci-build
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,7 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           # To test, use the TestPyPI:
-          # repository-url: https://test.pypi.org/legacy/
+          repository-url: https://test.pypi.org/legacy/
           # You must also create an account and project on TestPyPI,
           # as well as set the trusted-publisher in the project settings:
           # https://docs.pypi.org/trusted-publishers/adding-a-publisher/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 
-name: Build, Test, Sonar and Publish
+name: CI Build
 
 on:
   push:
@@ -13,14 +13,6 @@ on:
   pull_request:
   # run pipeline on merge queue
   merge_group:
-  # run pipeline from another workflow
-  workflow_call:
-    inputs:
-      create_release:
-        type: boolean
-        description: Create a (pre-)release when CI passes
-        default: false
-        required: false
   # run this workflow manually from the Actions tab
   workflow_dispatch:
     inputs:
@@ -35,6 +27,11 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  ci-started:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "ci started"
+
   build-test-release:
     name: build-test-release
     uses: "./.github/workflows/build-test-release.yml"
@@ -46,6 +43,19 @@ jobs:
       # otherwise create_release becomes false
       create_release: ${{ (github.event_name == 'workflow_dispatch' && inputs.create_release) || github.event_name == 'push'}}
 
+  check-code-quality:
+    uses: "./.github/workflows/check-code-quality.yml"
+
+  reuse-compliance:
+    uses: "./.github/workflows/reuse-compliance.yml"
+
+  ci-passed:
+    runs-on: ubuntu-latest
+    needs: [ci-started, build-test-release, check-code-quality, reuse-compliance]
+
+    steps:
+      - run: echo "ci passed"
+      
   publish:
     name: Publish to PyPI
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
     permissions:
       contents: write
       id-token: write  # Required for Trusted Publishing
-    needs: github-release
+    needs: build-test-release
     if: (github.event_name == 'workflow_dispatch') || github.event_name == 'push'
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
       contents: write
       id-token: write  # Required for Trusted Publishing
     needs: build-test-release
-    if: (github.event_name == 'workflow_dispatch') || github.event_name == 'push'
+    if: (github.event_name == 'workflow_dispatch' && inputs.create_release) || github.event_name == 'push'
 
     steps:
       - name: Download assets from GitHub release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,7 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           # To test, use the TestPyPI:
-          repository-url: https://test.pypi.org/legacy/
+          # repository-url: https://test.pypi.org/legacy/
           # You must also create an account and project on TestPyPI,
           # as well as set the trusted-publisher in the project settings:
           # https://docs.pypi.org/trusted-publishers/adding-a-publisher/

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -15,7 +15,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  main:
+  build-test-release:
     uses: "./.github/workflows/build-test-release.yml"
     permissions:
       contents: write

--- a/.github/workflows/reuse-compliance.yml
+++ b/.github/workflows/reuse-compliance.yml
@@ -6,13 +6,6 @@
 name: REUSE Compliance Check
 
 on:
-  push:
-    branches:
-      - main
-  # run pipeline on pull request
-  pull_request:
-  # run pipeline on merge queue
-  merge_group:
   # run pipeline from another workflow
   workflow_call:
   # run this workflow manually from the Actions tab

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: Contributors to the Power Grid Model project <powergridmodel@lfenergy.org>
+#
+# SPDX-License-Identifier: MPL-2.0
+
+name: Sonar Cloud
+
+on:
+  # run pipeline on push event of main branch
+  push:
+    branches:
+      - main
+  # run pipeline on pull request
+  pull_request:
+  # run pipeline on merge queue
+  merge_group:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-sonar
+  cancel-in-progress: true
+
+jobs:
+  sonar-cloud:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Checkout source code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+
+      - name: Setup Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install in develop mode
+        run: |
+          pip install -e .[dev]
+
+      - name: Test and Coverage
+        run: |
+          pytest
+
+          # Fix relative paths in coverage file
+          # Known bug: https://community.sonarsource.com/t/sonar-on-github-actions-with-python-coverage-source-issue/36057
+          sed -i 's@/home/runner/work/power-grid-model-io/power-grid-model-io@/github/workspace@g' python_coverage.xml
+
+      - name: SonarCloud Scan
+        if: ${{ (github.event_name == 'push') || (github.event.pull_request.head.repo.owner.login == 'PowerGridModel') }}
+        uses: SonarSource/sonarqube-scan-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -10,9 +10,7 @@ SPDX-License-Identifier: MPL-2.0
 [![Downloads](https://static.pepy.tech/badge/power-grid-model-io)](https://pepy.tech/project/power-grid-model-io)
 [![Downloads](https://static.pepy.tech/badge/power-grid-model-io/month)](https://pepy.tech/project/power-grid-model-io)
 
-[![Build and Test Python](https://github.com/PowerGridModel/power-grid-model-io/actions/workflows/build-test-and-sonar.yml/badge.svg)](https://github.com/PowerGridModel/power-grid-model-io/actions/workflows/build-test-and-sonar.yml)
-[![Check Code Quality](https://github.com/PowerGridModel/power-grid-model-io/actions/workflows/check-code-quality.yml/badge.svg)](https://github.com/PowerGridModel/power-grid-model-io/actions/workflows/check-code-quality.yml)
-[![REUSE Compliance Check](https://github.com/PowerGridModel/power-grid-model-io/actions/workflows/reuse-compliance.yml/badge.svg)](https://github.com/PowerGridModel/power-grid-model-io/actions/workflows/reuse-compliance.yml)
+[![CI Build](https://github.com/PowerGridModel/power-grid-model-io/actions/workflows/ci.yml/badge.svg)](https://github.com/PowerGridModel/power-grid-model-io/actions/workflows/ci.yml)
 [![docs](https://readthedocs.org/projects/power-grid-model-io/badge/)](https://power-grid-model-io.readthedocs.io/en/stable/)
 
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=PowerGridModel_power-grid-model-io&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=PowerGridModel_power-grid-model-io)
@@ -26,7 +24,7 @@ SPDX-License-Identifier: MPL-2.0
 
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.8059257.svg)](https://zenodo.org/record/8059257)
 
-[![](https://github.com/PowerGridModel/.github/blob/main/artwork/svg/color.svg)](#)
+[![Power Grid Model logo](https://github.com/PowerGridModel/.github/blob/main/artwork/svg/color.svg)](#)
 
 # Power Grid Model Input/Output
 


### PR DESCRIPTION
**Fixes**: 
publishing post v1.2.123

### Changes proposed in this PR include:

* Rename call of build-test-release
* Homogenize workflows in PGM and PGM-IO to make life easier

### Checks

- [x] If changes are related to CI/CD, are they verified via a manual run on this branch? (https://github.com/PowerGridModel/power-grid-model-io/actions/runs/15303577121)
