### PR TITLE
fix(exclude_empty): correcty handly pd.Series row[col] values

### DIFF
--- a/src/power_grid_model_io/functions/filters.py
+++ b/src/power_grid_model_io/functions/filters.py
@@ -18,10 +18,12 @@ def exclude_empty(row: pd.Series, col: str) -> bool:
     """
     if col not in row:
         raise ValueError(f"The column: '{col}' cannot be found for the filter")
-    result = has_value(row[col])
-    if isinstance(result, pd.Series):
-        return result.item()
-    return result
+
+    col_value = row[col]
+    if isinstance(col_value, pd.Series):
+        col_value = col_value.item()
+
+    return has_value(col_value)
 
 
 def exclude_value(row: pd.Series, col: str, value: float | str) -> bool:
@@ -30,11 +32,12 @@ def exclude_value(row: pd.Series, col: str, value: float | str) -> bool:
     """
     if col not in row:
         raise ValueError(f"The column: '{col}' cannot be found for the filter")
-    result = row[col] != value
-    # Sonar cloud false positive (S2583): result can be a pd.Series of bool
-    if isinstance(result, pd.Series):  # NOSONAR
-        return result.item()
-    return result
+
+    col_value = row[col]
+    if isinstance(col_value, pd.Series):
+        col_value = col_value.item()
+
+    return col_value != value
 
 
 def exclude_all_columns_empty_or_zero(row: pd.Series, cols: List[str]) -> bool:


### PR DESCRIPTION
**Fixes issue**: #322 

### Changes proposed in this PR include:
- Within the `exclude_empty` filter, we convert van `pd.Series` to a value before we call the `has_value` function instead of after. The `has_value` uses `isinstance` for certain checks, so a float check will otherwise fail. 
- I also updated `exclude_value` and added some tests, this function did work but I do think it's nice to transform as early as possible. 

### Could you please pay extra attention to the points below when reviewing the PR:
- 

- 
- 
- ..

### Checks

- [ ] If changes are related to CI/CD, are they verified via a manual run on this branch?
