### PR TITLE
Pandapower_converter bug fix: Resolve bug with broadcasting

### DIFF
--- a/src/power_grid_model_io/converters/pandapower_converter.py
+++ b/src/power_grid_model_io/converters/pandapower_converter.py
@@ -412,13 +412,6 @@ class PandaPowerConverter(BaseConverter[PandaPowerData]):
         parallel = self._get_pp_attr("line", "parallel", expected_type="u4", default=1)
         c_nf_per_km = self._get_pp_attr("line", "c_nf_per_km", expected_type="f8", default=0)
         c0_nf_per_km = self._get_pp_attr("line", "c0_nf_per_km", expected_type="f8", default=0)
-        g_us_per_km = self._get_pp_attr("line", "g_us_per_km", expected_type="f8", default=0)
-        g0_us_per_km = self._get_pp_attr("line", "g0_us_per_km", expected_type="f8", default=0)
-        # broadcast to array length
-        c_nf_per_km = c_nf_per_km * np.ones(shape=len(pp_lines), dtype="f8")
-        c0_nf_per_km = c0_nf_per_km * np.ones(shape=len(pp_lines), dtype="f8")
-        g_us_per_km = g_us_per_km * np.ones(shape=len(pp_lines), dtype="f8")
-        g0_us_per_km = g0_us_per_km * np.ones(shape=len(pp_lines), dtype="f8")
         multiplier = length_km / parallel
 
         pgm_lines = initialize_array(
@@ -433,12 +426,12 @@ class PandaPowerConverter(BaseConverter[PandaPowerData]):
         pgm_lines["x1"] = self._get_pp_attr("line", "x_ohm_per_km", expected_type="f8") * multiplier
         pgm_lines["c1"] = c_nf_per_km * length_km * parallel * 1e-9
         # The formula for tan1 = R_1 / Xc_1 = (g * 1e-6) / (2 * pi * f * c * 1e-9) = g / (2 * pi * f * c * 1e-3)
+        pgm_lines["tan1"] = 0.0
         pgm_lines["tan1"] = np.divide(
-            g_us_per_km,
+            self._get_pp_attr("line", "g_us_per_km", expected_type="f8", default=0),
             c_nf_per_km * (2 * np.pi * self.system_frequency * 1e-3),
             where=np.logical_not(np.isclose(c_nf_per_km, 0.0)),
         )
-        pgm_lines["tan1"][np.isclose(c_nf_per_km, 0.0)] = 0.0
         pgm_lines["i_n"] = (
             (self._get_pp_attr("line", "max_i_ka", expected_type="f8", default=np.nan) * 1e3)
             * self._get_pp_attr("line", "df", expected_type="f8", default=1)
@@ -447,12 +440,12 @@ class PandaPowerConverter(BaseConverter[PandaPowerData]):
         pgm_lines["r0"] = self._get_pp_attr("line", "r0_ohm_per_km", expected_type="f8", default=np.nan) * multiplier
         pgm_lines["x0"] = self._get_pp_attr("line", "x0_ohm_per_km", expected_type="f8", default=np.nan) * multiplier
         pgm_lines["c0"] = c0_nf_per_km * length_km * parallel * 1e-9
+        pgm_lines["tan0"] = 0.0
         pgm_lines["tan0"] = np.divide(
-            g0_us_per_km,
+            self._get_pp_attr("line", "g0_us_per_km", expected_type="f8", default=0),
             c0_nf_per_km * (2 * np.pi * self.system_frequency * 1e-3),
             where=np.logical_not(np.isclose(c0_nf_per_km, 0.0)),
         )
-        pgm_lines["tan0"][np.isclose(c0_nf_per_km, 0.0)] = 0.0
         assert ComponentType.line not in self.pgm_input_data
         self.pgm_input_data[ComponentType.line] = pgm_lines
 

--- a/tests/validation/converters/test_pandapower_converter_input.py
+++ b/tests/validation/converters/test_pandapower_converter_input.py
@@ -150,3 +150,13 @@ def test_pgm_input_lines__cnf_zero():
         pp_network.line.c0_nf_per_km = 0
         data, _ = pp_converter.load_input_data(pp_network)
         np.testing.assert_array_equal(data[ComponentType.line]["tan0"], 0)
+
+
+@pytest.mark.filterwarnings("error")
+def test_simple_example():
+    from pandapower.networks import example_simple
+
+    pp_net = example_simple()
+    pp_net["gen"] = pp_net["gen"].iloc[:0]
+    pp_converter = PandaPowerConverter()
+    data, _ = pp_converter.load_input_data(pp_net)


### PR DESCRIPTION
### Changes proposed in this PR include:

The changes proposed in PR #320 fixed known issues but created a bug in pgm_input_line function of pandapower_converter. in case of no data in column c0_nf_per_km, _get_attr_pp returns a single element array as it states broadcasting is responsibility of caller, but broadcasting was not handled, which creates error in assignment statemetns.

I've added another test to the /validation/converter/test_pandapower_converter_input.py, copied from pandapower tutorial power-grid-model_powerflow.ipynb, which fails on existing code.
