### PR TITLE
Fix: Remove Redundent Initialization to resolve reliability issue on Pypi.

### DIFF
--- a/src/power_grid_model_io/converters/pandapower_converter.py
+++ b/src/power_grid_model_io/converters/pandapower_converter.py
@@ -426,7 +426,6 @@ class PandaPowerConverter(BaseConverter[PandaPowerData]):
         pgm_lines["x1"] = self._get_pp_attr("line", "x_ohm_per_km", expected_type="f8") * multiplier
         pgm_lines["c1"] = c_nf_per_km * length_km * parallel * 1e-9
         # The formula for tan1 = R_1 / Xc_1 = (g * 1e-6) / (2 * pi * f * c * 1e-9) = g / (2 * pi * f * c * 1e-3)
-        pgm_lines["tan1"] = 0.0
         pgm_lines["tan1"] = np.divide(
             self._get_pp_attr("line", "g_us_per_km", expected_type="f8", default=0),
             c_nf_per_km * (2 * np.pi * self.system_frequency * 1e-3),
@@ -440,7 +439,6 @@ class PandaPowerConverter(BaseConverter[PandaPowerData]):
         pgm_lines["r0"] = self._get_pp_attr("line", "r0_ohm_per_km", expected_type="f8", default=np.nan) * multiplier
         pgm_lines["x0"] = self._get_pp_attr("line", "x0_ohm_per_km", expected_type="f8", default=np.nan) * multiplier
         pgm_lines["c0"] = c0_nf_per_km * length_km * parallel * 1e-9
-        pgm_lines["tan0"] = 0.0
         pgm_lines["tan0"] = np.divide(
             self._get_pp_attr("line", "g0_us_per_km", expected_type="f8", default=0),
             c0_nf_per_km * (2 * np.pi * self.system_frequency * 1e-3),

--- a/tests/unit/converters/test_pandapower_converter_input.py
+++ b/tests/unit/converters/test_pandapower_converter_input.py
@@ -596,7 +596,7 @@ def test_create_pgm_input_lines(mock_init_array: MagicMock, two_pp_objs, convert
     pgm.assert_any_call("r0", ANY)
     pgm.assert_any_call("x0", ANY)
     pgm.assert_any_call("c0", ANY)
-    assert len(pgm.call_args_list) == 16
+    assert len(pgm.call_args_list) == 14
 
     # result
     assert converter.pgm_input_data[ComponentType.line] == mock_init_array.return_value


### PR DESCRIPTION
### Changes proposed in this PR include:

Removed redundant initialisation lines that were causing reliability issue on Pypi concerning array values being set twice.
