### PR TITLE
[Improvement] Convert all supported elements' outputs with asymmetric load flow

### DIFF
--- a/src/power_grid_model_io/converters/pandapower_converter.py
+++ b/src/power_grid_model_io/converters/pandapower_converter.py
@@ -360,7 +360,7 @@ class PandaPowerConverter(BaseConverter[PandaPowerData]):
         Furthermore, creates a global node lookup table, which stores nodes' voltage magnitude per unit and the voltage
         angle in degrees
         """
-        # TODO create output_data_3ph for trafos3w
+        # TODO create output_data_3ph for trafos3w, switches
         self._pp_buses_output_3ph()
         self._pp_lines_output_3ph()
         self._pp_ext_grids_output_3ph()

--- a/src/power_grid_model_io/converters/pandapower_converter.py
+++ b/src/power_grid_model_io/converters/pandapower_converter.py
@@ -342,13 +342,13 @@ class PandaPowerConverter(BaseConverter[PandaPowerData]):
         self._pp_buses_output()
         self._pp_lines_output()
         self._pp_ext_grids_output()
-        self._pp_loads_output()
+        self._pp_load_elements_output(element="load", symmetric=True)
+        self._pp_load_elements_output(element="ward", symmetric=True)
+        self._pp_load_elements_output(element="motor", symmetric=True)
         self._pp_shunts_output()
         self._pp_trafos_output()
         self._pp_sgens_output()
         self._pp_trafos3w_output()
-        self._pp_ward_output()
-        self._pp_motor_output()
         self._pp_asym_gens_output()
         self._pp_asym_loads_output()
         # Switches derive results from branches pp_output_data and pgm_output_data of links. Hence, placed in the end.
@@ -361,17 +361,15 @@ class PandaPowerConverter(BaseConverter[PandaPowerData]):
         angle in degrees
         """
         # TODO create output_data_3ph for trafos3w
-        # Although Pandapower itself did not implmenet res_shunt_3ph
-        # Since results are avaiable in PGM output, these should be converted.
         self._pp_buses_output_3ph()
         self._pp_lines_output_3ph()
         self._pp_ext_grids_output_3ph()
-        self._pp_loads_output_3ph()
+        self._pp_load_elements_output(element="load", symmetric=False)
+        self._pp_load_elements_output(element="ward", symmetric=False)
+        self._pp_load_elements_output(element="motor", symmetric=False)
         self._pp_shunts_output_3ph()
         self._pp_trafos_output_3ph()
         self._pp_sgens_output_3ph()
-        self._pp_ward_output_3ph()
-        self._pp_motor_output_3ph()
         self._pp_asym_gens_output_3ph()
         self._pp_asym_loads_output_3ph()
 
@@ -1563,64 +1561,37 @@ class PandaPowerConverter(BaseConverter[PandaPowerData]):
 
         self.pp_output_data["res_asymmetric_sgen"] = pp_output_asym_gens
 
-    def _pp_loads_output(self):
+    def _pp_load_elements_output(self, element, symmetric):
         """
-        This function converts a power-grid-model Symmetrical Load output array to a Load Dataframe of PandaPower.
-
-        Returns:
-            a PandaPower Dataframe for the Load component
+        Utility function to convert output of elements represented as load
+        in power grid model.
+        element: "load", "motor" or "ward"
+        symmetric: True or False
         """
-        load_id_names = ["const_power", "const_impedance", "const_current"]
-        assert "res_load" not in self.pp_output_data
+        if symmetric:
+            res_table = "res_" + element
+        else:
+            res_table = "res_" + element + "_3ph"
+
+        if element == "load":
+            load_id_names = ["const_power", "const_impedance", "const_current"]
+        elif element == "ward":
+            load_id_names = ["ward_const_power_load", "ward_const_impedance_load"]
+        elif element == "motor":
+            load_id_names = ["motor_load"]
+
+        assert res_table not in self.pp_output_data
 
         if (
             ComponentType.sym_load not in self.pgm_output_data
             or self.pgm_output_data[ComponentType.sym_load].size == 0
-            or ("load", load_id_names[0]) not in self.idx
+            or (element, load_id_names[0]) not in self.idx
         ):
             return
-
         # Store the results, while assuring that we are not overwriting any data
-        assert "res_load" not in self.pp_output_data
-        self.pp_output_data["res_load"] = self._pp_load_result_accumulate(
-            pp_component_name="load", load_id_names=load_id_names
-        )
-
-    def _pp_ward_output(self):
-        load_id_names = ["ward_const_power_load", "ward_const_impedance_load"]
-        assert "res_ward" not in self.pp_output_data
-
-        if (
-            ComponentType.sym_load not in self.pgm_output_data
-            or self.pgm_output_data[ComponentType.sym_load].size == 0
-            or ("ward", load_id_names[0]) not in self.idx
-        ):
-            return
-
-        accumulated_loads = self._pp_load_result_accumulate(pp_component_name="ward", load_id_names=load_id_names)
-        # TODO Find a better way for mapping vm_pu from bus
-        # accumulated_loads["vm_pu"] = np.nan
-
-        # Store the results, while assuring that we are not overwriting any data
-        assert "res_ward" not in self.pp_output_data
-        self.pp_output_data["res_ward"] = accumulated_loads
-
-    def _pp_motor_output(self):
-        load_id_names = ["motor_load"]
-
-        assert "res_motor" not in self.pp_output_data
-
-        if (
-            ComponentType.sym_load not in self.pgm_output_data
-            or self.pgm_output_data[ComponentType.sym_load].size == 0
-            or ("motor", load_id_names[0]) not in self.idx
-        ):
-            return
-
-        # Store the results, while assuring that we are not overwriting any data
-        assert "res_motor" not in self.pp_output_data
-        self.pp_output_data["res_motor"] = self._pp_load_result_accumulate(
-            pp_component_name="motor", load_id_names=load_id_names
+        assert res_table not in self.pp_output_data
+        self.pp_output_data[res_table] = self._pp_load_result_accumulate(
+            pp_component_name=element, load_id_names=load_id_names
         )
 
     def _pp_load_result_accumulate(self, pp_component_name: str, load_id_names: List[str]) -> pd.DataFrame:
@@ -2133,64 +2104,6 @@ class PandaPowerConverter(BaseConverter[PandaPowerData]):
 
         assert "res_trafo_3ph" not in self.pp_output_data
         self.pp_output_data["res_trafo_3ph"] = pp_output_trafos_3ph
-
-    def _pp_loads_output_3ph(self):
-        """
-        This function converts a power-grid-model Symmetrical Load output array to a Load Dataframe of PandaPower.
-
-        Returns:
-            a PandaPower Dataframe for the Load component
-        """
-        load_id_names = ["const_power", "const_impedance", "const_current"]
-        if (
-            ComponentType.sym_load not in self.pgm_output_data
-            or self.pgm_output_data[ComponentType.sym_load].size == 0
-            or ("load", load_id_names[0]) not in self.idx
-        ):
-            return
-
-        # Store the results, while assuring that we are not overwriting any data
-        assert "res_load_3ph" not in self.pp_output_data
-        self.pp_output_data["res_load_3ph"] = self._pp_load_result_accumulate(
-            pp_component_name="load", load_id_names=load_id_names
-        )
-
-    def _pp_ward_output_3ph(self):
-        # TODO: Create Unit tests
-        load_id_names = ["ward_const_power_load", "ward_const_impedance_load"]
-        if (
-            ComponentType.sym_load not in self.pgm_output_data
-            or self.pgm_output_data[ComponentType.sym_load].size == 0
-            or ("ward", load_id_names[0]) not in self.idx
-        ):
-            return
-
-        # TODO Find a better way for mapping vm_pu from bus
-        # accumulated_loads["vm_pu"] = np.nan
-        # Store the results, while assuring that we are not overwriting any data
-        assert "res_ward_3ph" not in self.pp_output_data
-        self.pp_output_data["res_ward_3ph"] = self._pp_load_result_accumulate(
-            pp_component_name="ward", load_id_names=load_id_names
-        )
-
-    def _pp_motor_output_3ph(self):
-        # TODO: Create unit tests
-        load_id_names = ["motor_load"]
-
-        assert "res_motor_3ph" not in self.pp_output_data
-
-        if (
-            ComponentType.sym_load not in self.pgm_output_data
-            or self.pgm_output_data[ComponentType.sym_load].size == 0
-            or ("motor", load_id_names[0]) not in self.idx
-        ):
-            return
-
-        # Store the results, while assuring that we are not overwriting any data
-        assert "res_motor" not in self.pp_output_data
-        self.pp_output_data["res_motor_3ph"] = self._pp_load_result_accumulate(
-            pp_component_name="motor", load_id_names=load_id_names
-        )
 
     def _pp_shunts_output_3ph(self):
         """

--- a/src/power_grid_model_io/converters/pandapower_converter.py
+++ b/src/power_grid_model_io/converters/pandapower_converter.py
@@ -1580,8 +1580,6 @@ class PandaPowerConverter(BaseConverter[PandaPowerData]):
         elif element == "motor":
             load_id_names = ["motor_load"]
 
-        assert res_table not in self.pp_output_data
-
         if (
             ComponentType.sym_load not in self.pgm_output_data
             or self.pgm_output_data[ComponentType.sym_load].size == 0

--- a/tests/unit/converters/test_pandapower_converter_output.py
+++ b/tests/unit/converters/test_pandapower_converter_output.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: MPL-2.0
 
-from typing import Callable, List
+from typing import Any, Callable, Dict, List
 from unittest.mock import ANY, MagicMock, call, patch
 
 import numpy as np
@@ -74,34 +74,40 @@ def test_create_output_data_3ph():
 
 
 @pytest.mark.parametrize(
-    ("create_fn", "table"),
+    ("create_fn", "table", "create_fn_kwargs"),
     [
-        (PandaPowerConverter._pp_buses_output, "node"),
-        (PandaPowerConverter._pp_lines_output, "line"),
-        (PandaPowerConverter._pp_ext_grids_output, "source"),
-        (PandaPowerConverter._pp_shunts_output, "shunt"),
-        (PandaPowerConverter._pp_sgens_output, "sym_gen"),
-        (PandaPowerConverter._pp_trafos_output, "transformer"),
-        (PandaPowerConverter._pp_trafos3w_output, "three_winding_transformer"),
-        (PandaPowerConverter._pp_asym_loads_output, "asym_load"),
-        (PandaPowerConverter._pp_asym_gens_output, "asym_gen"),
-        (PandaPowerConverter._pp_switches_output, "link"),
-        (PandaPowerConverter._pp_buses_output_3ph, "node"),
-        (PandaPowerConverter._pp_lines_output_3ph, "line"),
-        (PandaPowerConverter._pp_ext_grids_output_3ph, "source"),
-        (PandaPowerConverter._pp_sgens_output_3ph, "sym_gen"),
-        (PandaPowerConverter._pp_trafos_output_3ph, "transformer"),
-        (PandaPowerConverter._pp_asym_loads_output_3ph, "asym_load"),
-        (PandaPowerConverter._pp_asym_gens_output_3ph, "asym_gen"),
+        (PandaPowerConverter._pp_buses_output, "node", {}),
+        (PandaPowerConverter._pp_lines_output, "line", {}),
+        (PandaPowerConverter._pp_ext_grids_output, "source", {}),
+        (PandaPowerConverter._pp_shunts_output, "shunt", {}),
+        (PandaPowerConverter._pp_sgens_output, "sym_gen", {}),
+        (PandaPowerConverter._pp_trafos_output, "transformer", {}),
+        (PandaPowerConverter._pp_trafos3w_output, "three_winding_transformer", {}),
+        (PandaPowerConverter._pp_load_elements_output, "load", {"symmetric": True, "element": "sym_load"}),
+        (PandaPowerConverter._pp_load_elements_output, "ward", {"symmetric": True, "element": "ward"}),
+        (PandaPowerConverter._pp_load_elements_output, "motor", {"symmetric": True, "element": "motor"}),
+        (PandaPowerConverter._pp_asym_loads_output, "asym_load", {}),
+        (PandaPowerConverter._pp_asym_gens_output, "asym_gen", {}),
+        (PandaPowerConverter._pp_switches_output, "link", {}),
+        (PandaPowerConverter._pp_buses_output_3ph, "node", {}),
+        (PandaPowerConverter._pp_lines_output_3ph, "line", {}),
+        (PandaPowerConverter._pp_ext_grids_output_3ph, "source", {}),
+        (PandaPowerConverter._pp_sgens_output_3ph, "sym_gen", {}),
+        (PandaPowerConverter._pp_trafos_output_3ph, "transformer", {}),
+        (PandaPowerConverter._pp_load_elements_output, "load", {"symmetric": False, "element": "sym_load"}),
+        (PandaPowerConverter._pp_load_elements_output, "ward", {"symmetric": False, "element": "ward"}),
+        (PandaPowerConverter._pp_load_elements_output, "motor", {"symmetric": False, "element": "motor"}),
+        (PandaPowerConverter._pp_asym_loads_output_3ph, "asym_load", {}),
+        (PandaPowerConverter._pp_asym_gens_output_3ph, "asym_gen", {}),
     ],
 )
-def test_create_pp_output_object__empty(create_fn: Callable[[PandaPowerConverter], None], table: str):
+def test_create_pp_output_object__empty(create_fn: Callable[..., None], table: str, create_fn_kwargs: Dict[str, Any]):
     # Arrange: No table
     converter = PandaPowerConverter()
 
     # Act / Assert
     with patch("power_grid_model_io.converters.pandapower_converter.pd.DataFrame") as mock_df:
-        create_fn(converter)
+        create_fn(converter, **create_fn_kwargs)
         mock_df.assert_not_called()
 
     # Arrange: Empty table
@@ -109,35 +115,7 @@ def test_create_pp_output_object__empty(create_fn: Callable[[PandaPowerConverter
 
     # Act / Assert
     with patch("power_grid_model_io.converters.pandapower_converter.pd.DataFrame") as mock_df:
-        create_fn(converter)
-        mock_df.assert_not_called()
-
-
-@pytest.mark.parametrize(
-    ("create_fn", "element", "symmetric", "table"),
-    [
-        (PandaPowerConverter._pp_load_elements_output, "load", True, "sym_load"),
-        (PandaPowerConverter._pp_load_elements_output, "ward", True, "ward"),
-        (PandaPowerConverter._pp_load_elements_output, "motor", True, "motor"),
-    ],
-)
-def test_create_pp_output_object_with_params__empty(
-    create_fn: Callable[[PandaPowerConverter, str, bool], None], element: str, symmetric: bool, table: str
-):
-    # Arrange: No table
-    converter = PandaPowerConverter()
-
-    # Act / Assert
-    with patch("power_grid_model_io.converters.pandapower_converter.pd.DataFrame") as mock_df:
-        create_fn(converter, element, symmetric)
-        mock_df.assert_not_called()
-
-    # Arrange: Empty table
-    converter.pgm_output_data[table] = np.array([])  # type: ignore
-
-    # Act / Assert
-    with patch("power_grid_model_io.converters.pandapower_converter.pd.DataFrame") as mock_df:
-        create_fn(converter, element, symmetric)
+        create_fn(converter, **create_fn_kwargs)
         mock_df.assert_not_called()
 
 

--- a/tests/unit/converters/test_pandapower_converter_output.py
+++ b/tests/unit/converters/test_pandapower_converter_output.py
@@ -83,6 +83,7 @@ def test_create_output_data_3ph():
         (PandaPowerConverter._pp_sgens_output, "sym_gen"),
         (PandaPowerConverter._pp_trafos_output, "transformer"),
         (PandaPowerConverter._pp_trafos3w_output, "three_winding_transformer"),
+        (PandaPowerConverter._pp_asym_loads_output, "asym_load"),
         (PandaPowerConverter._pp_asym_gens_output, "asym_gen"),
         (PandaPowerConverter._pp_switches_output, "link"),
         (PandaPowerConverter._pp_buses_output_3ph, "node"),

--- a/tests/unit/converters/test_pandapower_converter_output.py
+++ b/tests/unit/converters/test_pandapower_converter_output.py
@@ -54,7 +54,7 @@ def test_create_output_data_3ph():
     PandaPowerConverter._create_output_data_3ph(self=converter)  # type: ignore
 
     # Assert
-    assert len(converter.method_calls) == 8
+    assert len(converter.method_calls) == 11
     converter._pp_buses_output_3ph.assert_called_once_with()
     converter._pp_lines_output_3ph.assert_called_once_with()
     converter._pp_ext_grids_output_3ph.assert_called_once_with()

--- a/tests/validation/converters/test_pandapower_converter_output.py
+++ b/tests/validation/converters/test_pandapower_converter_output.py
@@ -8,8 +8,12 @@ from functools import lru_cache
 from pathlib import Path
 from typing import Tuple
 
+import numpy as np
+import pandapower.networks as pp_networks
 import pandas as pd
 import pytest
+from pandapower.results import reset_results
+from power_grid_model import PowerGridModel
 from power_grid_model.validation import assert_valid_input_data
 
 from power_grid_model_io.converters import PandaPowerConverter
@@ -286,8 +290,6 @@ def _get_total_powers_3ph(net):
     Input: Pandapower Network
     Output: [s_ext_grid, s_load, s_loss]
     """
-    from numpy import complex128
-
     s_ext_grid = (
         net.res_ext_grid_3ph.loc[:, ["p_a_mw", "p_b_mw", "p_c_mw"]].sum().sum()
         + 1j * net.res_ext_grid_3ph.loc[:, ["q_a_mvar", "q_b_mvar", "q_c_mvar"]].sum().sum()
@@ -299,27 +301,27 @@ def _get_total_powers_3ph(net):
             + 1j * net.res_asymmetric_load_3ph.loc[:, ["q_a_mvar", "q_b_mvar", "q_c_mvar"]].sum().sum()
         )
     else:
-        s_load_asym = complex128()
+        s_load_asym = np.complex128()
 
     if "res_load_3ph" in net:
         s_load_sym = net.res_load_3ph.loc[:, "p_mw"].sum() + 1j * net.res_load_3ph.loc[:, "q_mvar"].sum()
     else:
-        s_load_sym = complex128()
+        s_load_sym = np.complex128()
 
     if "res_motor_3ph" in net:
         s_motor = net.res_motor_3ph.loc[:, "p_mw"].sum() + 1j * net.res_motor_3ph.loc[:, "q_mvar"].sum()
     else:
-        s_motor = complex128()
+        s_motor = np.complex128()
 
     if ("res_ward_3ph" in net) and (not net.res_ward_3ph.empty):
         s_ward = net.res_ward_3ph.loc[:, "p_mw"].sum() + 1j * net.res_ward_3ph.loc[:, "q_mvar"].sum()
     else:
-        s_ward = complex128()
+        s_ward = np.complex128()
 
     if ("res_shunt_3ph" in net) and (not net.res_shunt_3ph.empty):
         s_shunt = net.res_shunt_3ph.loc[:, "p_mw"].sum() + 1j * net.res_shunt_3ph.loc[:, "q_mvar"].sum()
     else:
-        s_shunt = complex128()
+        s_shunt = np.complex128()
 
     s_load = s_load_sym + s_load_asym + s_motor + s_ward + s_shunt
 
@@ -329,7 +331,7 @@ def _get_total_powers_3ph(net):
             + 1j * net.res_line_3ph.loc[:, ["q_a_l_mvar", "q_b_l_mvar", "q_c_l_mvar"]].sum().sum()
         )
     else:
-        s_loss_line = complex128()
+        s_loss_line = np.complex128()
 
     if "res_trafo_3ph" in net:
         s_loss_trafo = (
@@ -337,7 +339,7 @@ def _get_total_powers_3ph(net):
             + 1j * net.res_trafo_3ph.loc[:, ["q_a_l_mvar", "q_b_l_mvar", "q_c_l_mvar"]].sum().sum()
         )
     else:
-        s_loss_trafo = complex128()
+        s_loss_trafo = np.complex128()
 
     s_loss = s_loss_line + s_loss_trafo
     return [s_ext_grid, s_load, s_loss]
@@ -345,9 +347,6 @@ def _get_total_powers_3ph(net):
 
 def test_output_data_3ph__powers():
     def run_pf_asym_with_pgm(net):
-        from pandapower.results import reset_results
-        from power_grid_model import PowerGridModel
-
         reset_results(net, "pf_3ph")
         pgm_converter = PandaPowerConverter()
         input_data, _ = pgm_converter.load_input_data(net, make_extra_info=False)
@@ -357,20 +356,17 @@ def test_output_data_3ph__powers():
         for table in output_tables.keys():
             net[table] = output_tables[table]
 
-    from numpy import isclose
-    from pandapower.networks import ieee_european_lv_asymmetric
-
-    net = ieee_european_lv_asymmetric()
+    net = pp_networks.ieee_european_lv_asymmetric()
     run_pf_asym_with_pgm(net)
     s_ext_grid, s_load, s_loss = _get_total_powers_3ph(net)
-    assert isclose(s_ext_grid, (s_load + s_loss))
+    assert np.isclose(s_ext_grid, (s_load + s_loss))
 
     pp.create_motor(net, 100, 0.1, 0.9)
     pp.create_ward(net, 200, 0.1, 0.05, 0.1, 0.05)
     pp.create_shunt_as_capacitor(net, 150, 0.09, 0)
     run_pf_asym_with_pgm(net)
     s_ext_grid, s_load, s_loss = _get_total_powers_3ph(net)
-    assert isclose(s_ext_grid, (s_load + s_loss))
+    assert np.isclose(s_ext_grid, (s_load + s_loss))
 
 
 def _get_total_powers(net):
@@ -379,46 +375,44 @@ def _get_total_powers(net):
     Input: Pandapower Network
     Output: [s_ext_grid, s_load, s_loss]
     """
-    from numpy import complex128
-
     s_ext_grid = net.res_ext_grid.loc[:, "p_mw"].sum() + 1j * net.res_ext_grid.loc[:, "q_mvar"].sum()
 
     if "res_asymmetric_load" in net:
         s_load_asym = net.res_asymmetric_load.loc[:, "p_mw"].sum() + 1j * net.res_asymmetric_load.loc[:, "q_mvar"].sum()
     else:
-        s_load_asym = complex128()
+        s_load_asym = np.complex128()
 
     if "res_load" in net:
         s_load_sym = net.res_load.loc[:, "p_mw"].sum() + 1j * net.res_load.loc[:, "q_mvar"].sum()
     else:
-        s_load_sym = complex128()
+        s_load_sym = np.complex128()
 
     if "res_motor" in net:
         s_motor = net.res_motor.loc[:, "p_mw"].sum() + 1j * net.res_motor.loc[:, "q_mvar"].sum()
     else:
-        s_motor = complex128()
+        s_motor = np.complex128()
 
     if "res_ward" in net:
         s_ward = net.res_ward.loc[:, "p_mw"].sum() + 1j * net.res_ward.loc[:, "q_mvar"].sum()
     else:
-        s_ward = complex128()
+        s_ward = np.complex128()
 
     if "res_shunt" in net:
         s_shunt = net.res_shunt.loc[:, "p_mw"].sum() + 1j * net.res_shunt.loc[:, "q_mvar"].sum()
     else:
-        s_shunt = complex128()
+        s_shunt = np.complex128()
 
     s_load = s_load_sym + s_load_asym + s_motor + s_ward + s_shunt
 
     if "res_line" in net:
         s_loss_line = net.res_line.loc[:, "pl_mw"].sum() + 1j * net.res_line.loc[:, "ql_mvar"].sum()
     else:
-        s_loss_line = complex128()
+        s_loss_line = np.complex128()
 
     if "res_trafo" in net:
         s_loss_trafo = net.res_trafo.loc[:, "pl_mw"].sum() + 1j * net.res_trafo.loc[:, "ql_mvar"].sum()
     else:
-        s_loss_trafo = complex128()
+        s_loss_trafo = np.complex128()
 
     s_loss = s_loss_line + s_loss_trafo
     return [s_ext_grid, s_load, s_loss]
@@ -426,9 +420,6 @@ def _get_total_powers(net):
 
 def test_output_data__powers():
     def run_pf_sym_with_pgm(net):
-        from pandapower.results import reset_results
-        from power_grid_model import PowerGridModel
-
         reset_results(net, "pf")
         pgm_converter = PandaPowerConverter()
         input_data, _ = pgm_converter.load_input_data(net, make_extra_info=False)
@@ -438,17 +429,14 @@ def test_output_data__powers():
         for table in output_tables.keys():
             net[table] = output_tables[table]
 
-    from numpy import isclose
-    from pandapower.networks import ieee_european_lv_asymmetric
-
-    net = ieee_european_lv_asymmetric()
+    net = pp_networks.ieee_european_lv_asymmetric()
     run_pf_sym_with_pgm(net)
     s_ext_grid, s_load, s_loss = _get_total_powers(net)
-    assert isclose(s_ext_grid, (s_load + s_loss))
+    assert np.isclose(s_ext_grid, (s_load + s_loss))
 
     pp.create_motor(net, 100, 0.1, 0.9)
     pp.create_ward(net, 200, 0.1, 0.05, 0.1, 0.05)
     pp.create_shunt_as_capacitor(net, 150, 0.09, 0)
     run_pf_sym_with_pgm(net)
     s_ext_grid, s_load, s_loss = _get_total_powers(net)
-    assert isclose(s_ext_grid, (s_load + s_loss))
+    assert np.isclose(s_ext_grid, (s_load + s_loss))

--- a/tests/validation/converters/test_pandapower_converter_output.py
+++ b/tests/validation/converters/test_pandapower_converter_output.py
@@ -306,7 +306,27 @@ def _get_total_powers_3ph(net):
     else:
         s_load_sym = complex128()
 
-    s_load = s_load_sym + s_load_asym
+    if "res_motor_3ph" in net:
+        s_motor = net.res_motor_3ph.loc[:, "p_mw"].sum() + 1j * net.res_motor_3ph.loc[:, "q_mvar"].sum()
+    else:
+        s_motor = complex128()
+
+    if "res_ward_3ph" in net:
+        s_ward = (
+            net.res_ward_3ph.loc[:, ["p_a_mw", "p_b_mw", "p_c_mw"]].sum().sum()
+            + 1j * net.res_ward_3ph.loc[:, ["q_a_mvar", "q_b_mvar", "q_c_mvar"]].sum().sum()
+        )
+    else:
+        s_ward = complex128()
+
+    # TODO: enable res_shunt_3ph when implemented, right now the table exists but columns not defined.
+    # if "res_shunt_3ph" in net:
+    #    print(net.res_shunt_3ph)
+    #    s_shunt = net.res_shunt_3ph.loc[:, "p_mw"].sum() + 1j * net.res_shunt_3ph.loc[:, "q_mvar"].sum()
+    # else:
+    s_shunt = complex128()
+
+    s_load = s_load_sym + s_load_asym + s_motor + s_ward + s_shunt
 
     if "res_line_3ph" in net:
         s_loss_line = (
@@ -316,7 +336,7 @@ def _get_total_powers_3ph(net):
     else:
         s_loss_line = complex128()
 
-    if "res_line_3ph" in net:
+    if "res_trafo_3ph" in net:
         s_loss_trafo = (
             net.res_trafo_3ph.loc[:, ["p_a_l_mw", "p_b_l_mw", "p_c_l_mw"]].sum().sum()
             + 1j * net.res_trafo_3ph.loc[:, ["q_a_l_mvar", "q_b_l_mvar", "q_c_l_mvar"]].sum().sum()
@@ -355,4 +375,85 @@ def test_output_data_3ph__powers():
     pp.create_shunt_as_capacitor(net, 150, 0.09, 0)
     run_pf_asym_with_pgm(net)
     s_ext_grid, s_load, s_loss = _get_total_powers_3ph(net)
+    assert isclose(s_ext_grid, (s_load + s_loss))
+
+
+def _get_total_powers(net):
+    """
+    Calculates total complex power for sources, loads and losses
+    Input: Pandapower Network
+    Output: [s_ext_grid, s_load, s_loss]
+    """
+    from numpy import complex128
+
+    s_ext_grid = net.res_ext_grid.loc[:, "p_mw"].sum() + 1j * net.res_ext_grid.loc[:, "q_mvar"].sum()
+
+    if "res_asymmetric_load" in net:
+        s_load_asym = net.res_asymmetric_load.loc[:, "p_mw"].sum() + 1j * net.res_asymmetric_load.loc[:, "q_mvar"].sum()
+    else:
+        s_load_asym = complex128()
+
+    if "res_load" in net:
+        s_load_sym = net.res_load.loc[:, "p_mw"].sum() + 1j * net.res_load.loc[:, "q_mvar"].sum()
+    else:
+        s_load_sym = complex128()
+
+    if "res_motor" in net:
+        s_motor = net.res_motor.loc[:, "p_mw"].sum() + 1j * net.res_motor.loc[:, "q_mvar"].sum()
+    else:
+        s_motor = complex128()
+
+    if "res_ward" in net:
+        s_ward = net.res_ward.loc[:, "p_mw"].sum() + 1j * net.res_ward.loc[:, "q_mvar"].sum()
+    else:
+        s_ward = complex128()
+
+    if "res_shunt" in net:
+        s_shunt = net.res_shunt.loc[:, "p_mw"].sum() + 1j * net.res_shunt.loc[:, "q_mvar"].sum()
+    else:
+        s_shunt = complex128()
+
+    s_load = s_load_sym + s_load_asym + s_motor + s_ward + s_shunt
+
+    if "res_line" in net:
+        s_loss_line = net.res_line.loc[:, "pl_mw"].sum() + 1j * net.res_line.loc[:, "ql_mvar"].sum()
+    else:
+        s_loss_line = complex128()
+
+    if "res_trafo" in net:
+        s_loss_trafo = net.res_trafo.loc[:, "pl_mw"].sum() + 1j * net.res_trafo.loc[:, "ql_mvar"].sum()
+    else:
+        s_loss_trafo = complex128()
+
+    s_loss = s_loss_line + s_loss_trafo
+    return [s_ext_grid, s_load, s_loss]
+
+
+def test_output_data__powers():
+    def run_pf_sym_with_pgm(net):
+        from pandapower.results import reset_results
+        from power_grid_model import PowerGridModel
+
+        reset_results(net, "pf")
+        pgm_converter = PandaPowerConverter()
+        input_data, _ = pgm_converter.load_input_data(net, make_extra_info=False)
+        pgm = PowerGridModel(input_data)
+        output_data = pgm.calculate_power_flow(symmetric=True)
+        output_tables = pgm_converter.convert(output_data)
+        for table in output_tables.keys():
+            net[table] = output_tables[table]
+
+    from numpy import isclose
+    from pandapower.networks import ieee_european_lv_asymmetric
+
+    net = ieee_european_lv_asymmetric()
+    run_pf_sym_with_pgm(net)
+    s_ext_grid, s_load, s_loss = _get_total_powers(net)
+    assert isclose(s_ext_grid, (s_load + s_loss))
+
+    pp.create_motor(net, 100, 0.1, 0.9)
+    pp.create_ward(net, 200, 0.1, 0.05, 0.1, 0.05)
+    pp.create_shunt_as_capacitor(net, 150, 0.09, 0)
+    run_pf_sym_with_pgm(net)
+    s_ext_grid, s_load, s_loss = _get_total_powers(net)
     assert isclose(s_ext_grid, (s_load + s_loss))

--- a/tests/validation/converters/test_pandapower_converter_output.py
+++ b/tests/validation/converters/test_pandapower_converter_output.py
@@ -357,6 +357,7 @@ def test_output_data_3ph__powers():
             net[table] = output_tables[table]
 
     net = pp_networks.ieee_european_lv_asymmetric()
+    pp.create_load(net, 50, 0.1, 0.05)
     run_pf_asym_with_pgm(net)
     s_ext_grid, s_load, s_loss = _get_total_powers_3ph(net)
     assert np.isclose(s_ext_grid, (s_load + s_loss))
@@ -430,6 +431,7 @@ def test_output_data__powers():
             net[table] = output_tables[table]
 
     net = pp_networks.ieee_european_lv_asymmetric()
+    pp.create_load(net, 50, 0.1, 0.05)
     run_pf_sym_with_pgm(net)
     s_ext_grid, s_load, s_loss = _get_total_powers(net)
     assert np.isclose(s_ext_grid, (s_load + s_loss))

--- a/tests/validation/converters/test_pandapower_converter_output.py
+++ b/tests/validation/converters/test_pandapower_converter_output.py
@@ -311,20 +311,15 @@ def _get_total_powers_3ph(net):
     else:
         s_motor = complex128()
 
-    if "res_ward_3ph" in net:
-        s_ward = (
-            net.res_ward_3ph.loc[:, ["p_a_mw", "p_b_mw", "p_c_mw"]].sum().sum()
-            + 1j * net.res_ward_3ph.loc[:, ["q_a_mvar", "q_b_mvar", "q_c_mvar"]].sum().sum()
-        )
+    if ("res_ward_3ph" in net) and (not net.res_ward_3ph.empty):
+        s_ward = net.res_ward_3ph.loc[:, "p_mw"].sum() + 1j * net.res_ward_3ph.loc[:, "q_mvar"].sum()
     else:
         s_ward = complex128()
 
-    # TODO: enable res_shunt_3ph when implemented, right now the table exists but columns not defined.
-    # if "res_shunt_3ph" in net:
-    #    print(net.res_shunt_3ph)
-    #    s_shunt = net.res_shunt_3ph.loc[:, "p_mw"].sum() + 1j * net.res_shunt_3ph.loc[:, "q_mvar"].sum()
-    # else:
-    s_shunt = complex128()
+    if ("res_shunt_3ph" in net) and (not net.res_shunt_3ph.empty):
+        s_shunt = net.res_shunt_3ph.loc[:, "p_mw"].sum() + 1j * net.res_shunt_3ph.loc[:, "q_mvar"].sum()
+    else:
+        s_shunt = complex128()
 
     s_load = s_load_sym + s_load_asym + s_motor + s_ward + s_shunt
 


### PR DESCRIPTION
### Changes proposed in this PR include:

The pandapower converter converts some elements like "shunt", "motor" and "ward" to pgm_input_data, but when output from pgm is converted back to pandapower with asymmetric load flow, these elements are not converted back. Resulting into a mismatch between power being injected by the source vs power being consumed/lost/inject by elements. Although Pandapower itself do not provide these output tables in case of 3ph power flow and the validation tests created here would fail if pf run with pandapower, but that do not stop us from improving the pgm_io.


### Checks

- [x] Implement res_shunt_3ph
- [x] Implement res_motor_3ph
- [x] Implement res_ward_3ph
