### PR TITLE
CI: pre-commit check naming

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,9 +13,11 @@ repos:
     hooks:
       # Run the linter.
       - id: ruff-check
+        name: ruff-check
         args: [ --fix ]
       # Run the formatter.
       - id: ruff-format
+        name: ruff-format
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.16.0
     hooks:


### PR DESCRIPTION
From `ruff check` to `ruff-check`, same for format. Align with main repo.