### PR TITLE
Add packaging dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ requires-python = ">=3.11"
 dependencies = [
     "numpy>=2.0",
     "openpyxl",
+    "packaging>=25.0",
     "pandas",
     "power_grid_model>=1.8",
     "pyyaml",


### PR DESCRIPTION
Added at #336

We should probably create a new action to run pipeline without dev dependencies. The dev dependencies here can actually create a very different set of dependencies compared to non group one.