### PR TITLE
Revert to default XML parser

### DIFF
--- a/docs/converters/tabular_converter.md
+++ b/docs/converters/tabular_converter.md
@@ -381,9 +381,12 @@ Mapping files enable the specification of custom mappings or filter functions.
 These functions can come from the `power-grid-model-io` library, be user-provided, or even supplied by third parties.
 To ensure security, we have implemented several measures.
 Best practices are recommended to prevent malicious code execution.
-XML parsing is performed using the defusedxml library instead of the standard library xml module.
-This ensures that unsafe XML features are disabled by default when processing mapping files or related inputs.
-[Python XML security](https://docs.python.org/3/library/xml.html#xml-security)
+XML parsing is performed using the standard library's `xml` module. For `python < 3.11`, `xml` was built
+with `expat = 2.6.0` which was vulnerable; however, `python >= 3.11` includes `expat = 2.7.1` which no
+longer is.
+This ensures that unsafe XML features are disabled by default when processing mapping files or related
+inputs. See the this [issue](https://github.com/python/cpython/issues/127502) and the
+[Python XML security](https://docs.python.org/3/library/xml.html#xml-security) documentation.
 
 ### Safe Loading of Configuration Files
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -167,7 +167,7 @@ select = [
     # pytest-style
     "PT",
 ]
-ignore = []
+ignore = ["S314"]  # S314: xml parsing is no longer considered unsafe python >= 3.11 (https://github.com/python/cpython/pull/135294)
 
 [tool.ruff.lint.isort]
 # Imports that are imported using keyword "as" and are from the same source - are combined.

--- a/src/power_grid_model_io/utils/excel_ambiguity_checker.py
+++ b/src/power_grid_model_io/utils/excel_ambiguity_checker.py
@@ -20,11 +20,10 @@ Requirements:
     - zipfile to handle the Excel file as a ZIP archive for parsing.
 """
 
+import xml.etree.ElementTree as ET
 import zipfile
 from collections import Counter
 from pathlib import Path
-
-from defusedxml import ElementTree as ET
 
 XML_NAME_SPACE = {"": "http://schemas.openxmlformats.org/spreadsheetml/2006/main"}  # NOSONAR
 WORK_BOOK = "xl/workbook.xml"


### PR DESCRIPTION
In #377 we switched from `xml` to `defusedxml` because of `ruff`'s [suggestion](https://docs.astral.sh/ruff/rules/suspicious-xml-expat-builder-usage/). This suggestion is outdated and only applies to `python < 3.11`. The reason is that the vulnerabilities existed only for `python < 3.11`,  as`xml` was built with `expat = 2.6.0` which was the source of such vulnerabilities. However, this no longer holds as `expat = 2.7.1` is used for `python >= 3.11` and `python <= 3.15`, removing such vulnerabilities.

See the following for references on the topic:
- https://github.com/python/cpython/pull/135294
- https://github.com/python/cpython/issues/127502
- https://docs.python.org/3/library/xml.html#the-defusedxml-package

In addition, the reason I found this is because the [feedstock build](https://github.com/conda-forge/power-grid-model-io-feedstock/pull/128#issuecomment-3998829039) failed due to `defusedxml` not being a "default" python dependency, which made me question the change and dig deeper into the issue.

C.C. @furqan463 I thought you would like to be tagged on this one.