### PR TITLE
chore: fix pgm logo rendering on pypi

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ SPDX-FileCopyrightText: Contributors to the Power Grid Model project <powergridm
 SPDX-License-Identifier: MPL-2.0
 -->
 
-[![Power Grid Model logo](https://github.com/PowerGridModel/.github/blob/main/artwork/svg/color.svg)](#) <!-- markdownlint-disable-line first-line-h1 no-empty-links line-length -->
+[![Power Grid Model logo](https://raw.githubusercontent.com/PowerGridModel/.github/main/artwork/svg/color.svg)](#) <!-- markdownlint-disable-line first-line-h1 line-length no-empty-links -->
 
 [![PyPI version](https://badge.fury.io/py/power-grid-model-io.svg?no-cache)](https://badge.fury.io/py/power-grid-model-io)
 [![PyPI Downloads](https://static.pepy.tech/badge/power-grid-model-io)](https://pepy.tech/project/power-grid-model-io)


### PR DESCRIPTION
Equivalent of https://github.com/PowerGridModel/power-grid-model/pull/1351

The PGM logo does not seem to render properly on https://pypi.org/project/power-grid-model-io/ . After a quick investigation done on the PGM repo, it turns out that even non-raw github links to SVGs are entire webpages, which PyPI is not able to render.

Tested on https://github.com/PowerGridModel/power-grid-model/pull/1351 + https://pypi.org/project/power-grid-model/