### PR TITLE
GitHub Actions: require actions to be pinned to full-length commit SHA

### DIFF
--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -33,13 +33,13 @@ jobs:
       version: ${{ steps.version.outputs.version }}
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
 
       - name: Set PyPI version
-        uses: PowerGridModel/pgm-version-bump@main
+        uses: PowerGridModel/pgm-version-bump@17f01ca0e845c35804c8c3c2490f61d14a77ede2 # v0.1.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -53,7 +53,7 @@ jobs:
         run: echo "version=$(cat PYPI_VERSION)" >> $GITHUB_OUTPUT
 
       - name: Store built wheel file
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: power-grid-model-io
           path: wheelhouse/
@@ -69,15 +69,15 @@ jobs:
 
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           python-version: ${{ matrix.python }}
 
       - name: Load built wheel file
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: power-grid-model-io
           path: wheelhouse/
@@ -102,15 +102,15 @@ jobs:
 
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           python-version: ${{ matrix.python }}
 
       - name: Load built wheel file
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: power-grid-model-io
           path: wheelhouse/
@@ -134,10 +134,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
 
       - name: Load built wheel file
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: power-grid-model-io
           path: wheelhouse/

--- a/.github/workflows/check-code-quality.yml
+++ b/.github/workflows/check-code-quality.yml
@@ -19,10 +19,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
 
       - name: Install most linters from uv
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
 
     steps:
       - name: Download assets from GitHub release
-        uses: robinraju/release-downloader@v1
+        uses: robinraju/release-downloader@daf26c55d821e836577a15f77d86ddc078948b05 # v1.12
         with:
           repository: ${{ github.repository }}
           # download the latest release
@@ -91,7 +91,7 @@ jobs:
         run: ls -la assets-to-publish
       
       - name: Upload assets to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           # To test, use the TestPyPI:
           # repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/citations.yml
+++ b/.github/workflows/citations.yml
@@ -30,9 +30,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Install R
       run: |
         sudo apt-get update && sudo apt-get install -y r-base
     - name: Validate CITATION.cff
-      uses: dieghernan/cff-validator@v4
+      uses: dieghernan/cff-validator@114aae53e1850c3757733beb60036941900e3dc3 # v4

--- a/.github/workflows/refresh-lock-and-linter-dependencies.yml
+++ b/.github/workflows/refresh-lock-and-linter-dependencies.yml
@@ -38,10 +38,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
 
       - name: upgrade uv lock
         run: uv lock --upgrade  
@@ -65,7 +65,7 @@ jobs:
           grab_installed_version "gersemi"
 
       - name: Update .pre-commit-config.yaml
-        uses: cuchi/jinja2-action@v1.3.0
+        uses: cuchi/jinja2-action@8bd801365a8d36a0b20f45ee969161685de7785a # v1.3.0
         with:
           template: .pre-commit-config.yaml.jinja
           output_file: .pre-commit-config.yaml
@@ -88,7 +88,7 @@ jobs:
           pre-commit uninstall
 
       - name: generate GitHub App token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         id: generate-token
         with:
           app-id: ${{ secrets.CI_BOT_APP_ID }}
@@ -96,7 +96,7 @@ jobs:
 
       - name: create pull request
         if: ${{ inputs.create-pr || github.event_name == 'schedule' }}
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           commit-message: "Refresh lock and linter dependencies"
           branch: "dependencies/refresh-lock-and-linter"

--- a/.github/workflows/reuse-compliance.yml
+++ b/.github/workflows/reuse-compliance.yml
@@ -20,6 +20,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: REUSE Compliance Check
-      uses: fsfe/reuse-action@v6
+      uses: fsfe/reuse-action@676e2d560c9a403aa252096d99fcab3e1132b0f5 # v6.0.0

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -26,12 +26,12 @@ jobs:
     steps:
 
       - name: Checkout source code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
 
       - name: Test and Coverage
         run: |
@@ -44,7 +44,7 @@ jobs:
 
       - name: SonarQube Scan
         if: ${{ (github.event_name == 'push') || (github.event.pull_request.head.repo.owner.login == 'PowerGridModel') }}
-        uses: SonarSource/sonarqube-scan-action@v7
+        uses: SonarSource/sonarqube-scan-action@299e4b793aaa83bf2aba7c9c14bedbb485688ec4 # v7.1.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
This is part of our goal to follow security best practices. See also https://docs.github.com/en/enterprise-cloud@latest/actions/reference/security/secure-use#using-third-party-actions

Cfr. https://docs.github.com/en/enterprise-cloud@latest/admin/enforcing-policies/enforcing-policies-for-your-enterprise/enforcing-policies-for-github-actions-in-your-enterprise#controlling-access-to-public-actions-and-reusable-workflows :

> Require actions to be pinned to a full-length commit SHA: All actions must be pinned to a full-length commit SHA to be used. This includes actions from your enterprise and actions authored by GitHub. Reusable workflows can still be referenced by tag. For more information, see [Secure use reference](https://docs.github.com/en/enterprise-cloud@latest/actions/reference/security/secure-use#using-third-party-actions).

So we have to pin also the GitHub-owned (`actions/checkout`, ...) and PowerGridModel-owned action (`pgm-version-bump`) before we can enable enforcing.

In addition, uv has migrated to no longer use rolling release tags (e.g. `v7`, `v8`, `v8.0`, ...) and instead requires us to use either the full tag (e.g. `v8.0.0`) or the full-length commit SHA (e.g. `cec208311dfd045dd5311c1add060b2062131d57`, optionally followed by a commented-out version of the tag, e.g. `cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0`). Further reading in https://github.com/astral-sh/setup-uv/releases/tag/v8.0.0 . This also means that we missed the latest version bump of uv. This feels like a good moment to jump, but let's let dependabot handle that, so we can 1. separate concerns, and 2. test whether the dependabot pipeline still works

## Relates to:

* https://github.com/PowerGridModel/power-grid-model/pull/1372
* https://github.com/PowerGridModel/power-grid-model-io/pull/412
* https://github.com/PowerGridModel/power-grid-model-ds/pull/228
* https://github.com/PowerGridModel/pgm-build-dependencies/pull/15
* https://github.com/PowerGridModel/pgm-version-bump/pull/9
* https://github.com/PowerGridModel/power-grid-model-workshop/pull/56
* https://github.com/PowerGridModel/power-grid-model-benchmark/pull/17
* https://github.com/PowerGridModel/homebrew-pgm/pull/1