### PR TITLE
Pandapower converter: allow string dtype columns in the pp converter

### DIFF
--- a/src/power_grid_model_io/converters/pandapower_converter.py
+++ b/src/power_grid_model_io/converters/pandapower_converter.py
@@ -47,6 +47,7 @@ except PackageNotFoundError:
     PP_CONVERSION_VERSION = PP_COMPATIBILITY_VERSION_3_4_0  # assume latest compatible version by default
 
 _NOT_SET_STR = "__PGM_PP_STR_NOT_SET"
+_PD_NA_TYPE = type(pd.NA)
 
 
 def get_loss_params_3ph():
@@ -2784,7 +2785,7 @@ class PandaPowerConverter(BaseConverter[PandaPowerData]):
         """
 
         @lru_cache
-        def vector_group_to_winding_types(vector_group: str | None | pd.missing.NAType) -> pd.Series:
+        def vector_group_to_winding_types(vector_group: str | None | _PD_NA_TYPE) -> pd.Series:  # type: ignore[valid-type]
             if pd.isna(vector_group) or vector_group is None or vector_group == _NOT_SET_STR:
                 return pd.Series([np.nan, np.nan])
 

--- a/src/power_grid_model_io/converters/pandapower_converter.py
+++ b/src/power_grid_model_io/converters/pandapower_converter.py
@@ -47,7 +47,6 @@ except PackageNotFoundError:
     PP_CONVERSION_VERSION = PP_COMPATIBILITY_VERSION_3_4_0  # assume latest compatible version by default
 
 _NOT_SET_STR = "__PGM_PP_STR_NOT_SET"
-_PD_NA_TYPE = type(pd.NA)
 
 
 def get_loss_params_3ph():
@@ -2785,7 +2784,7 @@ class PandaPowerConverter(BaseConverter[PandaPowerData]):
         """
 
         @lru_cache
-        def vector_group_to_winding_types(vector_group: str | None | _PD_NA_TYPE) -> pd.Series:  # type: ignore[valid-type]
+        def vector_group_to_winding_types(vector_group: str | None | pd.missing.NAType) -> pd.Series:
             if pd.isna(vector_group) or vector_group is None or vector_group == _NOT_SET_STR:
                 return pd.Series([np.nan, np.nan])
 

--- a/src/power_grid_model_io/converters/pandapower_converter.py
+++ b/src/power_grid_model_io/converters/pandapower_converter.py
@@ -2603,8 +2603,9 @@ class PandaPowerConverter(BaseConverter[PandaPowerData]):
         Returns:
             the "tap size" of Transformers
         """
-        tap_side_hv = np.array(pp_trafo[_PpAttr.tap_side] == "hv")
-        tap_side_lv = np.array(pp_trafo[_PpAttr.tap_side] == "lv")
+        tap_specified = ~pd.isna(pp_trafo[_PpAttr.tap_side])
+        tap_side_hv = np.array((pp_trafo[_PpAttr.tap_side] == "hv") & tap_specified)
+        tap_side_lv = np.array((pp_trafo[_PpAttr.tap_side] == "lv") & tap_specified)
         tap_step_multiplier = pp_trafo[_PpAttr.tap_step_percent] * (1e-2 * 1e3)
 
         tap_size = np.empty(shape=len(pp_trafo), dtype=np.float64)

--- a/src/power_grid_model_io/converters/pandapower_converter.py
+++ b/src/power_grid_model_io/converters/pandapower_converter.py
@@ -2856,7 +2856,7 @@ class PandaPowerConverter(BaseConverter[PandaPowerData]):
         attr_data = pp_component_data[attribute]
 
         # If any of the attribute values are missing, and a default is supplied, fill the nans with the default value
-        nan_values = np.equal(attr_data, None) if attr_data.dtype is np.dtype("O") else np.isnan(attr_data)  # type: ignore
+        nan_values = np.equal(attr_data, None) if attr_data.dtype is np.dtype("O") else pd.isna(attr_data)  # type: ignore
 
         if any(nan_values):
             attr_data = attr_data.fillna(value=default, inplace=False)

--- a/src/power_grid_model_io/converters/pandapower_converter.py
+++ b/src/power_grid_model_io/converters/pandapower_converter.py
@@ -47,6 +47,7 @@ except PackageNotFoundError:
     PP_CONVERSION_VERSION = PP_COMPATIBILITY_VERSION_3_4_0  # assume latest compatible version by default
 
 _NOT_SET_STR = "__PGM_PP_STR_NOT_SET"
+_PD_NA_TYPE = type(pd.NA)
 
 
 def get_loss_params_3ph():
@@ -2784,7 +2785,7 @@ class PandaPowerConverter(BaseConverter[PandaPowerData]):
         """
 
         @lru_cache
-        def vector_group_to_winding_types(vector_group: str | None | pd.NAType) -> pd.Series:
+        def vector_group_to_winding_types(vector_group: str | None | _PD_NA_TYPE) -> pd.Series:  # type: ignore[valid-type]
             if pd.isna(vector_group) or vector_group is None or vector_group == _NOT_SET_STR:
                 return pd.Series([np.nan, np.nan])
 

--- a/src/power_grid_model_io/converters/pandapower_converter.py
+++ b/src/power_grid_model_io/converters/pandapower_converter.py
@@ -46,6 +46,8 @@ try:
 except PackageNotFoundError:
     PP_CONVERSION_VERSION = PP_COMPATIBILITY_VERSION_3_4_0  # assume latest compatible version by default
 
+_NOT_SET_STR = "__PGM_PP_STR_NOT_SET"
+
 
 def get_loss_params_3ph():
     if PP_CONVERSION_VERSION < PP_COMPATIBILITY_VERSION_3_2_0:
@@ -708,7 +710,7 @@ class PandaPowerConverter(BaseConverter[PandaPowerData]):
         if ComponentType.sym_load in self.pgm_input_data:
             raise ValueError("Symmetrical Load component already exists in pgm_input_data")
 
-        if np.any(self._get_pp_attr(_PpTable.load, _PpAttr.type, expected_type="O", default=None) == "delta"):
+        if np.any(self._get_pp_attr(_PpTable.load, _PpAttr.type, expected_type="O", default=_NOT_SET_STR) == "delta"):
             raise NotImplementedError("Delta loads are not implemented, only wye loads are supported in PGM.")
 
         scaling = self._get_pp_attr(_PpTable.load, _PpAttr.scaling, expected_type="f8", default=1.0)
@@ -807,7 +809,8 @@ class PandaPowerConverter(BaseConverter[PandaPowerData]):
             raise ValueError("Asymmetric Load component already exists in pgm_input_data")
 
         if np.any(
-            self._get_pp_attr(_PpTable.asymmetric_load, _PpAttr.type, expected_type="O", default=None) == "delta"
+            self._get_pp_attr(_PpTable.asymmetric_load, _PpAttr.type, expected_type="O", default=_NOT_SET_STR)
+            == "delta"
         ):
             raise NotImplementedError("Delta loads are not implemented, only wye loads are supported in PGM.")
 
@@ -879,7 +882,7 @@ class PandaPowerConverter(BaseConverter[PandaPowerData]):
         sn_mva = self._get_pp_attr(_PpTable.trafo, _PpAttr.sn_mva, expected_type="f8")
         switch_states = self.get_switch_states(_PpTable.trafo)
 
-        tap_side = self._get_pp_attr(_PpTable.trafo, _PpAttr.tap_side, expected_type="O", default=None)
+        tap_side = self._get_pp_attr(_PpTable.trafo, _PpAttr.tap_side, expected_type="O", default=_NOT_SET_STR)
         tap_nom = self._get_pp_attr(_PpTable.trafo, _PpAttr.tap_neutral, expected_type="f8", default=np.nan)
         tap_pos = self._get_pp_attr(_PpTable.trafo, _PpAttr.tap_pos, expected_type="f8", default=np.nan)
         tap_size = self._get_tap_size(pp_trafo)
@@ -945,7 +948,7 @@ class PandaPowerConverter(BaseConverter[PandaPowerData]):
         p0_zero_sequence[np.logical_not(valid)] = np.nan
 
         # Do not use taps when mandatory tap data is not available
-        no_taps = np.equal(tap_side, None) | np.isnan(tap_pos) | np.isnan(tap_nom) | np.isnan(tap_size)
+        no_taps = np.equal(tap_side, _NOT_SET_STR) | np.isnan(tap_pos) | np.isnan(tap_nom) | np.isnan(tap_size)
         tap_nom[no_taps] = 0
         tap_pos[no_taps] = 0
         tap_size[no_taps] = 0
@@ -1034,7 +1037,7 @@ class PandaPowerConverter(BaseConverter[PandaPowerData]):
         sn_lv_mva = self._get_pp_attr(_PpTable.trafo3w, _PpAttr.sn_lv_mva, expected_type="f8")
         in_service = self._get_pp_attr(_PpTable.trafo3w, _PpAttr.in_service, expected_type="bool", default=True)
         switch_states = self.get_trafo3w_switch_states(pp_trafo3w)
-        tap_side = self._get_pp_attr(_PpTable.trafo3w, _PpAttr.tap_side, expected_type="O", default=None)
+        tap_side = self._get_pp_attr(_PpTable.trafo3w, _PpAttr.tap_side, expected_type="O", default=_NOT_SET_STR)
         tap_nom = self._get_pp_attr(_PpTable.trafo3w, _PpAttr.tap_neutral, expected_type="f8", default=np.nan)
         tap_pos = self._get_pp_attr(_PpTable.trafo3w, _PpAttr.tap_pos, expected_type="f8", default=np.nan)
         tap_size = self._get_3wtransformer_tap_size(pp_trafo3w)
@@ -1084,7 +1087,7 @@ class PandaPowerConverter(BaseConverter[PandaPowerData]):
             logger.warning("Zero sequence parameters given in trafo3w are ignored: %s", failed_checks)
 
         # Do not use taps when mandatory tap data is not available
-        no_taps = np.equal(tap_side, None) | np.isnan(tap_pos) | np.isnan(tap_nom) | np.isnan(tap_size)
+        no_taps = np.equal(tap_side, _NOT_SET_STR) | np.isnan(tap_pos) | np.isnan(tap_nom) | np.isnan(tap_size)
         tap_nom[no_taps] = 0
         tap_pos[no_taps] = 0
         tap_size[no_taps] = 0
@@ -2781,7 +2784,10 @@ class PandaPowerConverter(BaseConverter[PandaPowerData]):
         """
 
         @lru_cache
-        def vector_group_to_winding_types(vector_group: str) -> pd.Series:
+        def vector_group_to_winding_types(vector_group: str | None | pd.NAType) -> pd.Series:
+            if pd.isna(vector_group) or vector_group is None or vector_group == _NOT_SET_STR:
+                return pd.Series([np.nan, np.nan])
+
             trafo_connection = parse_trafo_connection(vector_group)
             winding_from = get_winding(trafo_connection["winding_from"]).value
             winding_to = get_winding(trafo_connection["winding_to"]).value
@@ -2856,7 +2862,11 @@ class PandaPowerConverter(BaseConverter[PandaPowerData]):
         attr_data = pp_component_data[attribute]
 
         # If any of the attribute values are missing, and a default is supplied, fill the nans with the default value
-        nan_values = np.equal(attr_data, None) if attr_data.dtype is np.dtype("O") else pd.isna(attr_data)  # type: ignore
+        nan_values = (
+            np.equal(attr_data, None) | pd.isna(attr_data)  # type: ignore
+            if attr_data.dtype is np.dtype("O")
+            else pd.isna(attr_data)
+        )
 
         if any(nan_values):
             attr_data = attr_data.fillna(value=default, inplace=False)

--- a/tests/unit/converters/test_pandapower_converter_input.py
+++ b/tests/unit/converters/test_pandapower_converter_input.py
@@ -25,6 +25,7 @@ from power_grid_model import (
 
 from power_grid_model_io._enum import PandapowerAttribute as _PpAttr, PandapowerTable as _PpTable
 from power_grid_model_io.converters.pandapower_converter import (
+    _NOT_SET_STR,
     PP_COMPATIBILITY_VERSION_3_2_0,
     PandaPowerConverter,
     get_loss_params_3ph,
@@ -810,7 +811,7 @@ def test_create_pgm_input_sym_loads(mock_init_array: MagicMock, two_pp_objs, con
     converter._get_pp_attr.assert_any_call(_PpTable.load, _PpAttr.q_mvar, expected_type="f8", default=0.0)
     converter._get_pp_attr.assert_any_call(_PpTable.load, _PpAttr.scaling, expected_type="f8", default=1)
     converter._get_pp_attr.assert_any_call(_PpTable.load, _PpAttr.in_service, expected_type="bool", default=True)
-    converter._get_pp_attr.assert_any_call(_PpTable.load, _PpAttr.type, expected_type="O", default=None)
+    converter._get_pp_attr.assert_any_call(_PpTable.load, _PpAttr.type, expected_type="O", default=_NOT_SET_STR)
     if pp_version < PP_COMPATIBILITY_VERSION_3_2_0:
         converter._get_pp_attr.assert_any_call(_PpTable.load, _PpAttr.const_z_percent, expected_type="f8", default=0)
         converter._get_pp_attr.assert_any_call(_PpTable.load, _PpAttr.const_i_percent, expected_type="f8", default=0)
@@ -869,7 +870,9 @@ def test_create_pgm_input_asym_loads(mock_init_array: MagicMock, two_pp_objs, co
     converter._get_pp_attr.assert_any_call(
         _PpTable.asymmetric_load, _PpAttr.in_service, expected_type="bool", default=True
     )
-    converter._get_pp_attr.assert_any_call(_PpTable.asymmetric_load, _PpAttr.type, expected_type="O", default=None)
+    converter._get_pp_attr.assert_any_call(
+        _PpTable.asymmetric_load, _PpAttr.type, expected_type="O", default=_NOT_SET_STR
+    )
     assert len(converter._get_pp_attr.call_args_list) == 10
 
     # assignment:
@@ -1026,6 +1029,7 @@ def test_create_pgm_input_shunts__bad_input():
 @patch("power_grid_model_io.converters.pandapower_converter.np.bitwise_and", new=lambda x, _: x)
 @patch("power_grid_model_io.converters.pandapower_converter.np.logical_and", new=lambda x, _: x)
 @patch("power_grid_model_io.converters.pandapower_converter.np.allclose", new=lambda x, _: x)
+@patch("power_grid_model_io.converters.pandapower_converter.np.equal", new=lambda x, _: x)
 @patch("power_grid_model_io.converters.pandapower_converter.np.isnan", new=lambda x: x)
 def test_create_pgm_input_transformers(mock_init_array: MagicMock, two_pp_objs, converter):  # noqa: PLR0915
     # Arrange
@@ -1046,7 +1050,7 @@ def test_create_pgm_input_transformers(mock_init_array: MagicMock, two_pp_objs, 
     )
     converter._get_tap_size.assert_called_once_with(two_pp_objs)
     converter._get_transformer_tap_side.assert_called_once_with(
-        _get_pp_attr(_PpTable.trafo, _PpAttr.tap_side, expected_type="O", default=None)
+        _get_pp_attr(_PpTable.trafo, _PpAttr.tap_side, expected_type="O", default=_NOT_SET_STR)
     )
 
     # initialization
@@ -1063,7 +1067,7 @@ def test_create_pgm_input_transformers(mock_init_array: MagicMock, two_pp_objs, 
     converter._get_pp_attr.assert_any_call(_PpTable.trafo, _PpAttr.pfe_kw, expected_type="f8")
     converter._get_pp_attr.assert_any_call(_PpTable.trafo, _PpAttr.i0_percent, expected_type="f8")
     converter._get_pp_attr.assert_any_call(_PpTable.trafo, _PpAttr.shift_degree, expected_type="f8", default=0.0)
-    converter._get_pp_attr.assert_any_call(_PpTable.trafo, _PpAttr.tap_side, expected_type="O", default=None)
+    converter._get_pp_attr.assert_any_call(_PpTable.trafo, _PpAttr.tap_side, expected_type="O", default=_NOT_SET_STR)
     converter._get_pp_attr.assert_any_call(_PpTable.trafo, _PpAttr.tap_neutral, expected_type="f8", default=np.nan)
     converter._get_pp_attr.assert_any_call(_PpTable.trafo, _PpAttr.tap_min, expected_type="i4", default=0)
     converter._get_pp_attr.assert_any_call(_PpTable.trafo, _PpAttr.tap_max, expected_type="i4", default=0)
@@ -1376,6 +1380,7 @@ def test_create_pgm_input_asym_gens__bad_input():
 
 
 @patch("power_grid_model_io.converters.pandapower_converter.initialize_array")
+@patch("power_grid_model_io.converters.pandapower_converter.np.equal", new=lambda x, _: x)
 @patch("power_grid_model_io.converters.pandapower_converter.np.round", new=lambda x: x)
 def test_create_pgm_input_three_winding_transformers(mock_init_array: MagicMock, two_pp_objs, converter):  # noqa: PLR0915
     # Arrange
@@ -1400,7 +1405,7 @@ def test_create_pgm_input_three_winding_transformers(mock_init_array: MagicMock,
     )
     converter._get_3wtransformer_tap_size.assert_called_once_with(two_pp_objs)
     converter._get_3wtransformer_tap_side.assert_called_once_with(
-        _get_pp_attr(_PpTable.trafo3w, _PpAttr.tap_side, expected_type="O", default=None)
+        _get_pp_attr(_PpTable.trafo3w, _PpAttr.tap_side, expected_type="O", default=_NOT_SET_STR)
     )
 
     # initialization
@@ -1428,7 +1433,7 @@ def test_create_pgm_input_three_winding_transformers(mock_init_array: MagicMock,
     converter._get_pp_attr.assert_any_call(_PpTable.trafo3w, _PpAttr.i0_percent, expected_type="f8")
     converter._get_pp_attr.assert_any_call(_PpTable.trafo3w, _PpAttr.shift_mv_degree, expected_type="f8", default=0.0)
     converter._get_pp_attr.assert_any_call(_PpTable.trafo3w, _PpAttr.shift_lv_degree, expected_type="f8", default=0.0)
-    converter._get_pp_attr.assert_any_call(_PpTable.trafo3w, _PpAttr.tap_side, expected_type="O", default=None)
+    converter._get_pp_attr.assert_any_call(_PpTable.trafo3w, _PpAttr.tap_side, expected_type="O", default=_NOT_SET_STR)
     converter._get_pp_attr.assert_any_call(_PpTable.trafo3w, _PpAttr.tap_neutral, expected_type="f8", default=np.nan)
     converter._get_pp_attr.assert_any_call(_PpTable.trafo3w, _PpAttr.tap_min, expected_type="i4", default=0)
     converter._get_pp_attr.assert_any_call(_PpTable.trafo3w, _PpAttr.tap_max, expected_type="i4", default=0)

--- a/tests/validation/converters/test_pandapower_converter_input.py
+++ b/tests/validation/converters/test_pandapower_converter_input.py
@@ -175,6 +175,15 @@ def test_simple_example():
     _, _ = pp_converter.load_input_data(pp_net)
 
 
+@pytest.mark.filterwarnings("error")
+def test_simple_example_with_strings():
+    pp_net = example_simple()
+    pp_net["load"]["type"] = pp_net["load"]["type"].astype(pd.StringDtype())
+    pp_net[_PpTable.gen] = pp_net[_PpTable.gen].iloc[:0]
+    pp_converter = PandaPowerConverter()
+    _, _ = pp_converter.load_input_data(pp_net)
+
+
 def test_trafo_zero_seq_params_conversion():
     net = pp_net_3ph_minimal_trafo()
     net.trafo.vector_group = "YNyn"

--- a/tests/validation/converters/test_pandapower_converter_input.py
+++ b/tests/validation/converters/test_pandapower_converter_input.py
@@ -205,12 +205,11 @@ def test_simple_example_with_na():
     for table, attrs in {
         _PpTable.line: [_PpAttr.type],
         _PpTable.trafo: [_PpAttr.vector_group, _PpAttr.tap_side],
-        _PpTable.trafo3w: [_PpAttr.tap_side],
         _PpTable.switch: [_PpAttr.type],
     }.items():
         for attr in attrs:
             pp_net[table][attr] = pp_net[table][attr].astype(pd.StringDtype())
-            pp_net[table][attr][0] = pd.NA
+            pp_net[table].loc[0, attr] = pd.NA
 
     pp_converter = PandaPowerConverter()
     _, _ = pp_converter.load_input_data(pp_net)

--- a/tests/validation/converters/test_pandapower_converter_input.py
+++ b/tests/validation/converters/test_pandapower_converter_input.py
@@ -178,8 +178,40 @@ def test_simple_example():
 @pytest.mark.filterwarnings("error")
 def test_simple_example_with_strings():
     pp_net = example_simple()
-    pp_net["load"]["type"] = pp_net["load"]["type"].astype(pd.StringDtype())
     pp_net[_PpTable.gen] = pp_net[_PpTable.gen].iloc[:0]
+
+    for table, attrs in {
+        _PpTable.bus: [_PpAttr.type],
+        _PpTable.load: [_PpAttr.type],
+        _PpTable.asymmetric_load: [_PpAttr.type],
+        _PpTable.sgen: [_PpAttr.type],
+        _PpTable.line: [_PpAttr.type],
+        _PpTable.trafo: [_PpAttr.vector_group, _PpAttr.tap_side],
+        _PpTable.trafo3w: [_PpAttr.tap_side],
+        _PpTable.switch: [_PpAttr.type],
+    }.items():
+        for attr in attrs:
+            pp_net[table][attr] = pp_net[table][attr].astype(pd.StringDtype())
+
+    pp_converter = PandaPowerConverter()
+    _, _ = pp_converter.load_input_data(pp_net)
+
+
+@pytest.mark.filterwarnings("error")
+def test_simple_example_with_na():
+    pp_net = example_simple()
+    pp_net[_PpTable.gen] = pp_net[_PpTable.gen].iloc[:0]
+
+    for table, attrs in {
+        _PpTable.line: [_PpAttr.type],
+        _PpTable.trafo: [_PpAttr.vector_group, _PpAttr.tap_side],
+        _PpTable.trafo3w: [_PpAttr.tap_side],
+        _PpTable.switch: [_PpAttr.type],
+    }.items():
+        for attr in attrs:
+            pp_net[table][attr] = pp_net[table][attr].astype(pd.StringDtype())
+            pp_net[table][attr][0] = pd.NA
+
     pp_converter = PandaPowerConverter()
     _, _ = pp_converter.load_input_data(pp_net)
 


### PR DESCRIPTION
Fixes #422 

This is relevant for pandapower 4.x compatibility