### PR TITLE
Bugfix: clean up excel file resources

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,7 @@ version = {file = "PYPI_VERSION"}
 power_grid_model_io = ["config/**/*.yaml", "py.typed"]
 
 [tool.pytest.ini_options]
-testpaths = ["tests/unit"]
+testpaths = ["tests"]
 addopts = [
     "--cov=power_grid_model_io",
     "--cov-report=term",

--- a/src/power_grid_model_io/converters/base_converter.py
+++ b/src/power_grid_model_io/converters/base_converter.py
@@ -69,8 +69,8 @@ class BaseConverter[T](ABC):
         Returns:
 
         """
-        with self._load_data(data) as data:
-            return self._parse_data(data=data, data_type=DatasetType.update, extra_info=None)
+        with self._load_data(data) as loaded_data:
+            return self._parse_data(data=loaded_data, data_type=DatasetType.update, extra_info=None)
 
     def load_sym_output_data(self, data: T | None = None) -> Dataset:
         """Load symmetric output data
@@ -173,15 +173,20 @@ class BaseConverter[T](ABC):
         """
         return self._logger.getEffectiveLevel()
 
-    def _load_data(self, data: T | None) -> T:
+    def _load_data(self, data: T | None) -> contextlib.AbstractContextManager[T]:
         if data is not None:
+
             @contextlib.contextmanager
             def data_context_manager():
                 yield data
+
             return data_context_manager()
 
         if self._source is not None:
-            return self._source.load()
+            loaded = self._source.load()
+            if isinstance(loaded, contextlib.AbstractContextManager):
+                return loaded
+            return contextlib.nullcontext(loaded)
 
         raise ValueError("No data supplied!")
 

--- a/src/power_grid_model_io/converters/base_converter.py
+++ b/src/power_grid_model_io/converters/base_converter.py
@@ -5,6 +5,7 @@
 Abstract converter class
 """
 
+import contextlib
 import logging
 from abc import ABC, abstractmethod
 
@@ -48,14 +49,14 @@ class BaseConverter[T](ABC):
 
         """
 
-        data = self._load_data(data)
-        extra_info: ExtraInfo = {}
-        parsed_data = self._parse_data(
-            data=data, data_type=DatasetType.input, extra_info=extra_info if make_extra_info else None
-        )
-        if isinstance(parsed_data, list):
-            raise TypeError("Input data can not be batch data")
-        return parsed_data, extra_info
+        with self._load_data(data) as loaded_data:
+            extra_info: ExtraInfo = {}
+            parsed_data = self._parse_data(
+                data=loaded_data, data_type=DatasetType.input, extra_info=extra_info if make_extra_info else None
+            )
+            if isinstance(parsed_data, list):
+                raise TypeError("Input data can not be batch data")
+            return parsed_data, extra_info
 
     def load_update_data(self, data: T | None = None) -> Dataset:
         """Load update data
@@ -68,8 +69,8 @@ class BaseConverter[T](ABC):
         Returns:
 
         """
-        data = self._load_data(data)
-        return self._parse_data(data=data, data_type=DatasetType.update, extra_info=None)
+        with self._load_data(data) as data:
+            return self._parse_data(data=data, data_type=DatasetType.update, extra_info=None)
 
     def load_sym_output_data(self, data: T | None = None) -> Dataset:
         """Load symmetric output data
@@ -82,8 +83,8 @@ class BaseConverter[T](ABC):
         Returns:
 
         """
-        data = self._load_data(data)
-        return self._parse_data(data=data, data_type=DatasetType.sym_output, extra_info=None)
+        with self._load_data(data) as loaded_data:
+            return self._parse_data(data=loaded_data, data_type=DatasetType.sym_output, extra_info=None)
 
     def load_asym_output_data(self, data: T | None = None) -> Dataset:
         """Load asymmetric output data
@@ -96,8 +97,8 @@ class BaseConverter[T](ABC):
         Returns:
 
         """
-        data = self._load_data(data)
-        return self._parse_data(data=data, data_type=DatasetType.asym_output, extra_info=None)
+        with self._load_data(data) as loaded_data:
+            return self._parse_data(data=loaded_data, data_type=DatasetType.asym_output, extra_info=None)
 
     def load_sc_output_data(self, data: T | None = None) -> Dataset:
         """Load sc output data
@@ -110,8 +111,8 @@ class BaseConverter[T](ABC):
         Returns:
 
         """
-        data = self._load_data(data)
-        return self._parse_data(data=data, data_type=DatasetType.sc_output, extra_info=None)
+        with self._load_data(data) as loaded_data:
+            return self._parse_data(data=loaded_data, data_type=DatasetType.sc_output, extra_info=None)
 
     def convert(self, data: Dataset, extra_info: ExtraInfo | None = None) -> T:
         """Convert input/update/(a)sym_output data and optionally extra info.
@@ -174,9 +175,14 @@ class BaseConverter[T](ABC):
 
     def _load_data(self, data: T | None) -> T:
         if data is not None:
-            return data
+            @contextlib.contextmanager
+            def data_context_manager():
+                yield data
+            return data_context_manager()
+
         if self._source is not None:
             return self._source.load()
+
         raise ValueError("No data supplied!")
 
     @abstractmethod  # pragma: nocover

--- a/src/power_grid_model_io/data_stores/excel_file_store.py
+++ b/src/power_grid_model_io/data_stores/excel_file_store.py
@@ -102,7 +102,7 @@ class ExcelFileStore(BaseDataStore[TabularData]):
             return sheet_loader
 
         data: dict[str, LazyDataFrame] = {}
-        open_readers: pd.ExcelFile = []
+        open_readers: list[pd.ExcelFile] = []
         for name, path in self._file_paths.items():
             open_readers.append(pd.ExcelFile(path))
             excel_file = open_readers[-1]

--- a/src/power_grid_model_io/data_stores/excel_file_store.py
+++ b/src/power_grid_model_io/data_stores/excel_file_store.py
@@ -102,8 +102,10 @@ class ExcelFileStore(BaseDataStore[TabularData]):
             return sheet_loader
 
         data: dict[str, LazyDataFrame] = {}
+        open_readers: pd.ExcelFile = []
         for name, path in self._file_paths.items():
-            excel_file = pd.ExcelFile(path)
+            open_readers.append(pd.ExcelFile(path))
+            excel_file = open_readers[-1]
             for sheet_name in excel_file.sheet_names:
                 loader = lazy_sheet_loader(excel_file, sheet_name)
                 # If the Excel file is not the main file, prefix the sheet name with the file name
@@ -111,7 +113,8 @@ class ExcelFileStore(BaseDataStore[TabularData]):
                 if main_sheet_name in data:
                     raise ValueError(f"Duplicate sheet name '{main_sheet_name}'")
                 data[main_sheet_name] = loader
-        return TabularData(**data)
+
+        return TabularData(**data, open_readers=open_readers)
 
     def save(self, data: TabularData) -> None:
         """

--- a/src/power_grid_model_io/data_types/tabular_data.py
+++ b/src/power_grid_model_io/data_types/tabular_data.py
@@ -6,8 +6,10 @@ The TabularData class is a wrapper around Dict[str, pd.DataFrame | np.ndarray],
 which supports unit conversions and value substitutions
 """
 
+import contextlib
 import logging
 from collections.abc import Callable, Generator, Iterable
+from typing import Protocol
 
 import numpy as np
 import pandas as pd
@@ -19,13 +21,25 @@ from power_grid_model_io.mappings.value_mapping import ValueMapping
 LazyDataFrame = Callable[[], pd.DataFrame]
 
 
+class Closeable(Protocol):
+    """Protocol for objects that expose a close() method."""
+
+    def close(self) -> None:
+        """Close the underlying resource."""
+
+
 class TabularData:
     """
     The TabularData class is a wrapper around Dict[str, pd.DataFrame | np.ndarray],
     which supports unit conversions and value substitutions
     """
 
-    def __init__(self, logger=None, **tables: pd.DataFrame | np.ndarray | LazyDataFrame):
+    def __init__(
+        self,
+        logger=None,
+        open_readers=None,
+        **tables: pd.DataFrame | np.ndarray | LazyDataFrame,
+    ):
         """
         Tabular data can either be a collection of pandas DataFrames and/or numpy structured arrays.
         The key word arguments will define the keys of the data.
@@ -34,6 +48,9 @@ class TabularData:
         tabular_data["foo"] --> foo_data
 
         Args:
+            logger (optional): A structlog logger to use for logging. If None, a default logger will be created.
+            open_readers (optional): A list of readers to be closed when the TabularData instance is closed.
+                These objects must implement a close() method.
             **tables: A collection of pandas DataFrames and/or numpy structured arrays
         """
         if logger is None:
@@ -51,6 +68,28 @@ class TabularData:
         self._data: dict[str, pd.DataFrame | np.ndarray | LazyDataFrame] = tables
         self._units: UnitMapping | None = None
         self._substitution: ValueMapping | None = None
+        self._open_readers: list[Closeable] = open_readers if open_readers is not None else []
+
+    def __new__(cls, *args, **kwargs):  # noqa: ARG004
+        instance = super().__new__(cls)
+        instance._open_readers = None
+        return instance
+
+    def __del__(self):
+        self.close()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
+
+    def close(self):
+        if self._open_readers:
+            for reader in self._open_readers:
+                with contextlib.suppress(Exception):
+                    reader.close()
+        self._open_readers = None
 
     def set_unit_multipliers(self, units: UnitMapping) -> None:
         """

--- a/src/power_grid_model_io/utils/uuid_excel_cvtr.py
+++ b/src/power_grid_model_io/utils/uuid_excel_cvtr.py
@@ -233,21 +233,22 @@ def convert_guid_vision_excel(
     """
     if terms_changed is None:
         terms_changed = {}
-    xls = load_excel_file(excel_file)
-    cvtr = UUID2IntCvtr()
-    excel_file_path = Path(excel_file)
-    dir_name, file_name = excel_file_path.parent, excel_file_path.name
-    new_excel_name = dir_name / f"new_{file_name}"
 
-    for i, sheet_name in enumerate(xls.sheet_names):
-        df = xls.parse(sheet_name)
-        update_column_names(df, terms_changed)
-        guid_columns = get_guid_columns(df)
+    with load_excel_file(excel_file) as xls:
+        cvtr = UUID2IntCvtr()
+        excel_file_path = Path(excel_file)
+        dir_name, file_name = excel_file_path.parent, excel_file_path.name
+        new_excel_name = dir_name / f"new_{file_name}"
 
-        for guid_column in guid_columns:
-            add_guid_values_to_cvtr(df, guid_column, cvtr)
-            insert_or_update_number_column(df, guid_column, sheet_name, cvtr, number)
+        for i, sheet_name in enumerate(xls.sheet_names):
+            df = xls.parse(sheet_name)
+            update_column_names(df, terms_changed)
+            guid_columns = get_guid_columns(df)
 
-        save_df_to_excel(df, new_excel_name, sheet_name, i)
+            for guid_column in guid_columns:
+                add_guid_values_to_cvtr(df, guid_column, cvtr)
+                insert_or_update_number_column(df, guid_column, sheet_name, cvtr, number)
+
+            save_df_to_excel(df, new_excel_name, sheet_name, i)
 
     return new_excel_name

--- a/tests/unit/converters/test_base_converter.py
+++ b/tests/unit/converters/test_base_converter.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 import logging
-from unittest.mock import ANY, MagicMock
+from unittest.mock import ANY, MagicMock, patch
 
 import numpy as np
 import pytest
@@ -58,6 +58,17 @@ def test_load_input_data(converter: DummyConverter):
     assert extra_info == {1: "Foo"}
 
 
+def test_load_input_data__resource_cleanup(converter: DummyConverter):
+    converter._load_data = MagicMock()
+
+    # Act
+    converter.load_input_data(data=None)
+
+    # Assert
+    converter._load_data.return_value.__enter__.assert_called_once()
+    converter._load_data.return_value.__exit__.assert_called_once()
+
+
 def test_load_input_data__no_extra_info(converter: DummyConverter):
     # Arrange
     mock_data = MagicMock()
@@ -93,6 +104,17 @@ def test_load_update_data(converter: DummyConverter):
     assert data == {"foo": 1}
 
 
+def test_load_update_data__resource_cleanup(converter: DummyConverter):
+    converter._load_data = MagicMock()
+
+    # Act
+    converter.load_update_data(data=None)
+
+    # Assert
+    converter._load_data.return_value.__enter__.assert_called_once()
+    converter._load_data.return_value.__exit__.assert_called_once()
+
+
 def test_load_sym_output_data(converter: DummyConverter):
     # Arrange
     converter._parse_data.return_value = {"foo": 1}  # type: ignore
@@ -105,6 +127,17 @@ def test_load_sym_output_data(converter: DummyConverter):
         data={CT.node: [{AT.id: 1}, {AT.id: 2}]}, data_type=DatasetType.sym_output, extra_info=None
     )
     assert data == {"foo": 1}
+
+
+def test_load_sym_output_data__resource_cleanup(converter: DummyConverter):
+    converter._load_data = MagicMock()
+
+    # Act
+    converter.load_sym_output_data(data=None)
+
+    # Assert
+    converter._load_data.return_value.__enter__.assert_called_once()
+    converter._load_data.return_value.__exit__.assert_called_once()
 
 
 def test_load_asym_output_data(converter: DummyConverter):
@@ -133,6 +166,17 @@ def test_load_sc_output_data(converter: DummyConverter):
         data={CT.node: [{AT.id: 1}, {AT.id: 2}]}, data_type=DatasetType.sc_output, extra_info=None
     )
     assert data == {"foo": 1}
+
+
+def test_load_asym_output_data__resource_cleanup(converter: DummyConverter):
+    converter._load_data = MagicMock()
+
+    # Act
+    converter.load_asym_output_data(data=None)
+
+    # Assert
+    converter._load_data.return_value.__enter__.assert_called_once()
+    converter._load_data.return_value.__exit__.assert_called_once()
 
 
 def test_convert_data(converter: DummyConverter):
@@ -166,13 +210,17 @@ def test_load_data(converter: DummyConverter):
         converter._load_data(data=None)
 
     input_data = {"node": [{"id": 1}, {"id": 2}]}
-    output_data = converter._load_data(data=input_data)
-    assert output_data == input_data
+    with converter._load_data(data=input_data) as output_data:
+        assert output_data == input_data
 
     source = MagicMock()
     converter_2 = DummyConverter(source=source)
-    converter_2._load_data(data=None)
+    with converter_2._load_data(data=None):
+        pass
+
     source.load.assert_called_once()
+    source.load.return_value.__enter__.assert_called_once()
+    source.load.return_value.__exit__.assert_called_once()
 
 
 def test_base_converter_log_level():

--- a/tests/unit/converters/test_base_converter.py
+++ b/tests/unit/converters/test_base_converter.py
@@ -151,6 +151,16 @@ def test_load_asym_output_data(converter: DummyConverter):
     assert data == {"foo": 1}
 
 
+def test_load_asym_output_data__resource_cleanup(converter: DummyConverter):
+    with patch.object(converter, "_load_data") as load_data:
+        # Act
+        converter.load_asym_output_data(data=None)
+
+        # Assert
+        load_data.return_value.__enter__.assert_called_once()
+        load_data.return_value.__exit__.assert_called_once()
+
+
 def test_load_sc_output_data(converter: DummyConverter):
     # Arrange
     converter._parse_data.return_value = {"foo": 1}  # type: ignore
@@ -165,10 +175,10 @@ def test_load_sc_output_data(converter: DummyConverter):
     assert data == {"foo": 1}
 
 
-def test_load_asym_output_data__resource_cleanup(converter: DummyConverter):
+def test_load_sc_output_data__resource_cleanup(converter: DummyConverter):
     with patch.object(converter, "_load_data") as load_data:
         # Act
-        converter.load_asym_output_data(data=None)
+        converter.load_sc_output_data(data=None)
 
         # Assert
         load_data.return_value.__enter__.assert_called_once()

--- a/tests/unit/converters/test_base_converter.py
+++ b/tests/unit/converters/test_base_converter.py
@@ -184,9 +184,10 @@ def test_convert_data(converter: DummyConverter):
 
 
 def test_save_data(converter: DummyConverter):
-    # No destination supplied
+    # No destination supplie
+    data = {"foo": np.array([1])}
     with pytest.raises(ValueError, match="No destination supplied!"):
-        converter.save(data={"foo": np.array([1])})
+        converter.save(data=data)
 
     # Destination supplied as argument
     destination = MagicMock()

--- a/tests/unit/converters/test_base_converter.py
+++ b/tests/unit/converters/test_base_converter.py
@@ -59,14 +59,13 @@ def test_load_input_data(converter: DummyConverter):
 
 
 def test_load_input_data__resource_cleanup(converter: DummyConverter):
-    converter._load_data = MagicMock()
+    with patch.object(converter, "_load_data") as load_data:
+        # Act
+        converter.load_input_data(data=None)
 
-    # Act
-    converter.load_input_data(data=None)
-
-    # Assert
-    converter._load_data.return_value.__enter__.assert_called_once()
-    converter._load_data.return_value.__exit__.assert_called_once()
+        # Assert
+        load_data.return_value.__enter__.assert_called_once()
+        load_data.return_value.__exit__.assert_called_once()
 
 
 def test_load_input_data__no_extra_info(converter: DummyConverter):
@@ -105,14 +104,13 @@ def test_load_update_data(converter: DummyConverter):
 
 
 def test_load_update_data__resource_cleanup(converter: DummyConverter):
-    converter._load_data = MagicMock()
+    with patch.object(converter, "_load_data") as load_data:
+        # Act
+        converter.load_update_data(data=None)
 
-    # Act
-    converter.load_update_data(data=None)
-
-    # Assert
-    converter._load_data.return_value.__enter__.assert_called_once()
-    converter._load_data.return_value.__exit__.assert_called_once()
+        # Assert
+        load_data.return_value.__enter__.assert_called_once()
+        load_data.return_value.__exit__.assert_called_once()
 
 
 def test_load_sym_output_data(converter: DummyConverter):
@@ -130,14 +128,13 @@ def test_load_sym_output_data(converter: DummyConverter):
 
 
 def test_load_sym_output_data__resource_cleanup(converter: DummyConverter):
-    converter._load_data = MagicMock()
+    with patch.object(converter, "_load_data") as load_data:
+        # Act
+        converter.load_sym_output_data(data=None)
 
-    # Act
-    converter.load_sym_output_data(data=None)
-
-    # Assert
-    converter._load_data.return_value.__enter__.assert_called_once()
-    converter._load_data.return_value.__exit__.assert_called_once()
+        # Assert
+        load_data.return_value.__enter__.assert_called_once()
+        load_data.return_value.__exit__.assert_called_once()
 
 
 def test_load_asym_output_data(converter: DummyConverter):
@@ -169,14 +166,13 @@ def test_load_sc_output_data(converter: DummyConverter):
 
 
 def test_load_asym_output_data__resource_cleanup(converter: DummyConverter):
-    converter._load_data = MagicMock()
+    with patch.object(converter, "_load_data") as load_data:
+        # Act
+        converter.load_asym_output_data(data=None)
 
-    # Act
-    converter.load_asym_output_data(data=None)
-
-    # Assert
-    converter._load_data.return_value.__enter__.assert_called_once()
-    converter._load_data.return_value.__exit__.assert_called_once()
+        # Assert
+        load_data.return_value.__enter__.assert_called_once()
+        load_data.return_value.__exit__.assert_called_once()
 
 
 def test_convert_data(converter: DummyConverter):

--- a/tests/unit/data_stores/test_excel_file_store.py
+++ b/tests/unit/data_stores/test_excel_file_store.py
@@ -113,16 +113,18 @@ def test_load(
     mock_handle_duplicate_columns.side_effect = noop
 
     # Act
-    data = fs.load()
+    with fs.load() as data:
+        # Assert
+        mock_excel_file.assert_called_once()
+        assert mock_excel_file.return_value.is_open
+        pd.testing.assert_frame_equal(data["Nodes"], objects_excel["Nodes"])
+        pd.testing.assert_frame_equal(data["Lines"], objects_excel["Lines"])
+        assert mock_remove_unnamed_column_placeholders.call_args_list[0] == call(data=objects_excel["Nodes"])
+        assert mock_remove_unnamed_column_placeholders.call_args_list[1] == call(data=objects_excel["Lines"])
+        assert mock_handle_duplicate_columns.call_args_list[0] == call(data=objects_excel["Nodes"], sheet_name="Nodes")
+        assert mock_handle_duplicate_columns.call_args_list[1] == call(data=objects_excel["Lines"], sheet_name="Lines")
 
-    # Assert
-    mock_excel_file.assert_called_once()
-    pd.testing.assert_frame_equal(data["Nodes"], objects_excel["Nodes"])
-    pd.testing.assert_frame_equal(data["Lines"], objects_excel["Lines"])
-    assert mock_remove_unnamed_column_placeholders.call_args_list[0] == call(data=objects_excel["Nodes"])
-    assert mock_remove_unnamed_column_placeholders.call_args_list[1] == call(data=objects_excel["Lines"])
-    assert mock_handle_duplicate_columns.call_args_list[0] == call(data=objects_excel["Nodes"], sheet_name="Nodes")
-    assert mock_handle_duplicate_columns.call_args_list[1] == call(data=objects_excel["Lines"], sheet_name="Lines")
+    assert not mock_excel_file.return_value.is_open
 
 
 @patch("power_grid_model_io.data_stores.excel_file_store.ExcelFileStore._handle_duplicate_columns")

--- a/tests/unit/data_stores/test_excel_file_store.py
+++ b/tests/unit/data_stores/test_excel_file_store.py
@@ -71,18 +71,22 @@ def test_constructor__kwargs():
 
 def test_constructor__too_many_args():
     # Too many (> 1) unnamed arguments
+    a_path = Path("A.xlsx")
+    b_path = Path("B.xls")
     with pytest.raises(TypeError, match=r"1 to 2.*positional arguments.*3.*given"):
-        ExcelFileStore(Path("A.xlsx"), Path("B.xls"))  # type: ignore
+        ExcelFileStore(a_path, b_path)  # type: ignore
 
 
 def test_constructor__invalid_main_file():
+    path = Path("A.docx")
     with pytest.raises(ValueError, match=r"Excel.*\.docx"):
-        ExcelFileStore(Path("A.docx"))
+        ExcelFileStore(path)
 
 
 def test_constructor__invalid_named_file():
+    path = Path("A.xlsx")
     with pytest.raises(ValueError, match=r"Extra.*\.docx"):
-        ExcelFileStore(Path("A.xlsx"), extra=Path("B.docx"))
+        ExcelFileStore(path, extra=Path("B.docx"))
 
 
 def test_files__read_only():

--- a/tests/unit/data_stores/test_excel_file_store.py
+++ b/tests/unit/data_stores/test_excel_file_store.py
@@ -84,9 +84,10 @@ def test_constructor__invalid_main_file():
 
 
 def test_constructor__invalid_named_file():
-    path = Path("A.xlsx")
+    a_path = Path("A.xlsx")
+    b_path = Path("B.docx")
     with pytest.raises(ValueError, match=r"Extra.*\.docx"):
-        ExcelFileStore(path, extra=Path("B.docx"))
+        ExcelFileStore(a_path, extra=b_path)
 
 
 def test_files__read_only():

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -275,6 +275,7 @@ class MockDf:
 class MockExcelFile:
     def __init__(self, data: dict[str, pd.DataFrame]):
         self.data = data
+        self._is_open = True
 
     @property
     def sheet_names(self) -> list[str]:
@@ -282,6 +283,13 @@ class MockExcelFile:
 
     def parse(self, sheet_name: str, **_kwargs) -> pd.DataFrame:
         return self.data[sheet_name]
+
+    def close(self):
+        self._is_open = False
+
+    @property
+    def is_open(self):
+        return self._is_open
 
 
 class MockTqdm:

--- a/tests/validation/converters/test_pandapower_converter_input.py
+++ b/tests/validation/converters/test_pandapower_converter_input.py
@@ -99,7 +99,7 @@ def test_input_data(input_data: tuple[SingleDataset, SingleDataset]):
         assert len(expected) <= len(actual)
 
 
-@pytest.mark.parametrize(("component", "attribute"), component_attributes(VALIDATION_FILE, data_type=DatasetType.input))
+@pytest.mark.parametrize(("component", "attribute"), list(component_attributes(VALIDATION_FILE, data_type=DatasetType.input)))
 def test_attributes(input_data: tuple[SingleDataset, SingleDataset], component: CT, attribute: AT):
     """
     For each attribute, check if the actual values are consistent with the expected values
@@ -122,7 +122,7 @@ def test_attributes(input_data: tuple[SingleDataset, SingleDataset], component: 
 
 @pytest.mark.parametrize(
     ("component", "obj_ids"),
-    (pytest.param(component, objects, id=component) for component, objects in component_objects(VALIDATION_FILE)),
+    [pytest.param(component, objects, id=component) for component, objects in component_objects(VALIDATION_FILE)],
 )
 def test_extra_info(extra_info: tuple[ExtraInfo, ExtraInfo], component: CT, obj_ids: list[int]):
     """

--- a/tests/validation/converters/test_pandapower_converter_input.py
+++ b/tests/validation/converters/test_pandapower_converter_input.py
@@ -99,7 +99,9 @@ def test_input_data(input_data: tuple[SingleDataset, SingleDataset]):
         assert len(expected) <= len(actual)
 
 
-@pytest.mark.parametrize(("component", "attribute"), list(component_attributes(VALIDATION_FILE, data_type=DatasetType.input)))
+@pytest.mark.parametrize(
+    ("component", "attribute"), list(component_attributes(VALIDATION_FILE, data_type=DatasetType.input))
+)
 def test_attributes(input_data: tuple[SingleDataset, SingleDataset], component: CT, attribute: AT):
     """
     For each attribute, check if the actual values are consistent with the expected values

--- a/tests/validation/converters/test_pandapower_converter_output.py
+++ b/tests/validation/converters/test_pandapower_converter_output.py
@@ -286,7 +286,7 @@ def test_output_data_3ph(output_data_3ph: tuple[PandaPowerData, PandaPowerData])
     assert all(key in expected for key in actual)
 
 
-@pytest.mark.parametrize(("component", "attribute"), component_attributes_df(load_and_convert_pgm_data()))
+@pytest.mark.parametrize(("component", "attribute"), list(component_attributes_df(load_and_convert_pgm_data())))
 def test_attributes(output_data: tuple[PandaPowerData, PandaPowerData], component: CT, attribute: AT):
     """
     For each attribute, check if the actual values are consistent with the expected values
@@ -302,7 +302,7 @@ def test_attributes(output_data: tuple[PandaPowerData, PandaPowerData], componen
     pd.testing.assert_series_equal(actual_values, expected_values, atol=5e-4, rtol=1e-4)
 
 
-@pytest.mark.parametrize(("component", "attribute"), component_attributes_df(load_and_convert_pgm_data_3ph()))
+@pytest.mark.parametrize(("component", "attribute"), list(component_attributes_df(load_and_convert_pgm_data_3ph())))
 def test_attributes_3ph(
     output_data_3ph: tuple[PandaPowerData, PandaPowerData],
     component: CT,

--- a/tests/validation/converters/test_vision_excel_converter.py
+++ b/tests/validation/converters/test_vision_excel_converter.py
@@ -115,7 +115,9 @@ def test_input_data_custom_yaml():
         assert len(expected) <= len(actual)
 
 
-@pytest.mark.parametrize(("component", "attribute"), list(component_attributes(VALIDATION_EN, data_type=DatasetType.input)))
+@pytest.mark.parametrize(
+    ("component", "attribute"), list(component_attributes(VALIDATION_EN, data_type=DatasetType.input))
+)
 @pytest.mark.parametrize("input_data", LANGUAGES, indirect=True)
 def test_attributes(input_data: tuple[SingleDataset, SingleDataset], component: CT, attribute: AT):
     """

--- a/tests/validation/converters/test_vision_excel_converter.py
+++ b/tests/validation/converters/test_vision_excel_converter.py
@@ -115,7 +115,7 @@ def test_input_data_custom_yaml():
         assert len(expected) <= len(actual)
 
 
-@pytest.mark.parametrize(("component", "attribute"), component_attributes(VALIDATION_EN, data_type=DatasetType.input))
+@pytest.mark.parametrize(("component", "attribute"), list(component_attributes(VALIDATION_EN, data_type=DatasetType.input)))
 @pytest.mark.parametrize("input_data", LANGUAGES, indirect=True)
 def test_attributes(input_data: tuple[SingleDataset, SingleDataset], component: CT, attribute: AT):
     """
@@ -133,7 +133,7 @@ def test_attributes(input_data: tuple[SingleDataset, SingleDataset], component: 
 
 @pytest.mark.parametrize(
     ("component", "obj_ids"),
-    (pytest.param(component, objects, id=component) for component, objects in component_objects(VALIDATION_EN)),
+    [pytest.param(component, objects, id=component) for component, objects in component_objects(VALIDATION_EN)],
 )
 @pytest.mark.parametrize("extra_info", LANGUAGES, indirect=True)
 def test_extra_info(extra_info: tuple[ExtraInfo, ExtraInfo], component: CT, obj_ids: list[int]):


### PR DESCRIPTION
by default, `pytest` does not run the validation cases. E.g. `uv run pytest` will return

```
800 passed in 8.77s
```

# this branch
```
1404 passed, 6 warnings in 9.87s
```

c.c. @furqan463 if you remember, we have talked about this. This enables validation pytest cases by default.

## Related bug

During creation of this PR, #452 was found. This branch also contains the fix for it.

Fixes #452 