### PR TITLE
Restrict pandas version to less than 3.0 in optional dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "numpy>=2.0",
     "openpyxl",
     "packaging>=25.0",
-    "pandas<3.0",  # pandapower does not yet support pandas 3.x https://github.com/e2nIEE/pandapower/issues/2861
+    "pandas",
     "power_grid_model>=1.8",
     "pyyaml",
     "structlog",
@@ -46,6 +46,7 @@ test = [
     "pytest-cov",
     "pydantic>2", # Used in unit tests
     "pandapower>2.11.1",
+    "pandas<3.0",  # pandapower does not yet support pandas 3.x https://github.com/e2nIEE/pandapower/issues/2861
     "lxml", # missing pandapower dependency
 ]
 
@@ -64,6 +65,7 @@ dev = [{ include-group = "test" }, { include-group = "lint" }]
 examples = [
     "power-grid-model>=1.13.27",
     "pandapower>2.11.1",
+    "pandas<3.0",  # pandapower does not yet support pandas 3.x https://github.com/e2nIEE/pandapower/issues/2861
     "pyarrow", # Pyarrow support for Python 3.12 scheduled for 14.0.0: https://github.com/apache/arrow/issues/37880
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "numpy>=2.0",
     "openpyxl",
     "packaging>=25.0",
-    "pandas",
+    "pandas<3.0",  # pandapower does not yet support pandas 3.x https://github.com/e2nIEE/pandapower/issues/2861
     "power_grid_model>=1.8",
     "pyyaml",
     "structlog",

--- a/uv.lock
+++ b/uv.lock
@@ -1559,6 +1559,7 @@ dev = [
     { name = "mypy" },
     { name = "numpy" },
     { name = "pandapower" },
+    { name = "pandas" },
     { name = "pre-commit" },
     { name = "pydantic" },
     { name = "pytest" },
@@ -1577,6 +1578,7 @@ doc = [
 ]
 examples = [
     { name = "pandapower" },
+    { name = "pandas" },
     { name = "power-grid-model" },
     { name = "pyarrow" },
 ]
@@ -1592,6 +1594,7 @@ lint = [
 test = [
     { name = "lxml" },
     { name = "pandapower" },
+    { name = "pandas" },
     { name = "pydantic" },
     { name = "pytest" },
     { name = "pytest-cov" },
@@ -1615,6 +1618,7 @@ dev = [
     { name = "mypy" },
     { name = "numpy" },
     { name = "pandapower", specifier = ">2.11.1" },
+    { name = "pandas", specifier = "<3.0" },
     { name = "pre-commit" },
     { name = "pydantic", specifier = ">2" },
     { name = "pytest" },
@@ -1633,6 +1637,7 @@ doc = [
 ]
 examples = [
     { name = "pandapower", specifier = ">2.11.1" },
+    { name = "pandas", specifier = "<3.0" },
     { name = "power-grid-model", specifier = ">=1.13.27" },
     { name = "pyarrow" },
 ]
@@ -1648,6 +1653,7 @@ lint = [
 test = [
     { name = "lxml" },
     { name = "pandapower", specifier = ">2.11.1" },
+    { name = "pandas", specifier = "<3.0" },
     { name = "pydantic", specifier = ">2" },
     { name = "pytest" },
     { name = "pytest-cov" },


### PR DESCRIPTION
Unblocks #474 
Relates to https://github.com/e2nIEE/pandapower/issues/2861
