### PR TITLE
docs: use public API module paths

### DIFF
--- a/docs/power_grid_model_io.md
+++ b/docs/power_grid_model_io.md
@@ -32,6 +32,7 @@ SPDX-License-Identifier: MPL-2.0
 .. automodule:: power_grid_model_io.data_types
    :imported-members:
 .. autodata:: power_grid_model_io.data_types.StructuredData
+
 ```
 
 ## functions

--- a/docs/power_grid_model_io.md
+++ b/docs/power_grid_model_io.md
@@ -29,14 +29,16 @@ SPDX-License-Identifier: MPL-2.0
 ## data_types
 
 ```{eval-rst}
-.. automodule:: power_grid_model_io.data_types._data_types
-.. automodule:: power_grid_model_io.data_types.tabular_data
+.. automodule:: power_grid_model_io.data_types
+   :imported-members:
+.. autodata:: power_grid_model_io.data_types.StructuredData
 ```
 
 ## functions
 
 ```{eval-rst}
-.. automodule:: power_grid_model_io.functions._functions
+.. automodule:: power_grid_model_io.functions
+   :imported-members:
 .. automodule:: power_grid_model_io.functions.phase_to_phase
 ```
 


### PR DESCRIPTION
Generates the re-exported data types and helper functions from their public package modules, so API signatures and anchors use the public `power_grid_model_io.data_types.*` and `power_grid_model_io.functions.*` paths.

Fixes #243

Validation: full pre-commit suite; Sphinx HTML build and rendered-name checks.
