### PR TITLE
fix: batch Vision GUID number columns

### DIFF
--- a/src/power_grid_model_io/data_stores/excel_file_store.py
+++ b/src/power_grid_model_io/data_stores/excel_file_store.py
@@ -19,7 +19,6 @@ from power_grid_model_io.data_stores.base_data_store import (
 from power_grid_model_io.data_types import LazyDataFrame, TabularData
 from power_grid_model_io.utils.uuid_excel_cvtr import (
     UUID2IntCvtr,
-    add_guid_values_to_cvtr,
     get_special_key_map,
     special_nodes_en,
     special_nodes_nl,
@@ -238,19 +237,43 @@ class ExcelFileStore(BaseDataStore[TabularData]):
             sheet_name=sheet_name, nodes_en=special_nodes_en, nodes_nl=special_nodes_nl
         )
 
+        insertions: dict[int, tuple[str | tuple[str, ...], pd.Series]] = {}
         for guid_column in guid_columns:
             nr = VISION_EXCEL_LAN_DICT[self._language][DICT_KEY_NUMBER]
-            add_guid_values_to_cvtr(data, guid_column, self._uuid_cvtr)
+            guid_column_pos = first_level.tolist().index(guid_column)
+            guid_values = data.iloc[:, guid_column_pos]
+            self._uuid_cvtr.add_list(guid_values.tolist())
             new_column_name = guid_column.replace("GUID", nr)
             if guid_column == "GUID" and sheet_key_mapping not in (None, {}):
                 new_column_name = guid_column.replace("GUID", sheet_key_mapping[DICT_KEY_SUBNUMBER])
-            guid_column_pos = first_level.tolist().index(guid_column)
-            try:
-                data.insert(guid_column_pos + 1, new_column_name, data[guid_column].apply(self._uuid_cvtr.query))
-            except ValueError:
-                data[new_column_name] = data[guid_column].apply(self._uuid_cvtr.query)
 
-        return data
+            number_values = guid_values.apply(self._uuid_cvtr.query)
+            if new_column_name in first_level:
+                number_column_pos = first_level.tolist().index(new_column_name)
+                data.iloc[:, number_column_pos] = number_values
+                continue
+
+            column_name: str | tuple[str, ...] = new_column_name
+            if data.columns.nlevels > 1:
+                column_name = (new_column_name, *("" for _ in range(data.columns.nlevels - 1)))
+            insertions[guid_column_pos] = (column_name, number_values)
+
+        if not insertions:
+            return data
+
+        columns = []
+        for column_pos in range(len(data.columns)):
+            columns.append(data.iloc[:, [column_pos]])
+            if insertion := insertions.get(column_pos):
+                column_name, values = insertion
+                new_column = values.to_frame()
+                if isinstance(column_name, tuple):
+                    new_column.columns = pd.MultiIndex.from_tuples([column_name], names=data.columns.names)
+                else:
+                    new_column.columns = pd.Index([column_name], name=data.columns.name)
+                columns.append(new_column)
+
+        return pd.concat(columns, axis=1)
 
     def _update_column_names(self, data: pd.DataFrame) -> pd.DataFrame:
         update_column_names(data, self._terms_changed)

--- a/src/power_grid_model_io/data_stores/excel_file_store.py
+++ b/src/power_grid_model_io/data_stores/excel_file_store.py
@@ -250,7 +250,7 @@ class ExcelFileStore(BaseDataStore[TabularData]):
             number_values = guid_values.apply(self._uuid_cvtr.query)
             if new_column_name in first_level:
                 number_column_pos = first_level.tolist().index(new_column_name)
-                data.iloc[:, number_column_pos] = number_values
+                data.isetitem(number_column_pos, number_values)
                 continue
 
             column_name: str | tuple[str, ...] = new_column_name

--- a/tests/unit/data_stores/test_excel_file_store.py
+++ b/tests/unit/data_stores/test_excel_file_store.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: MPL-2.0
 
+import warnings
 from pathlib import Path
 from unittest.mock import MagicMock, call, patch
 
@@ -300,6 +301,46 @@ def test_remove_unnamed_column_placeholders__empty():
 
     # Assert
     pd.testing.assert_frame_equal(result, data)
+
+
+def test_process_uuid_columns_batches_insertions_without_fragmentation_warning():
+    # A large Vision export previously emitted PerformanceWarning and reversed
+    # most generated columns because every insertion shifted later positions.
+    data = pd.DataFrame({f"Field{i}GUID": [f"guid-{i}"] for i in range(105)})
+    store = ExcelFileStore()
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", pd.errors.PerformanceWarning)
+        result = store._process_uuid_columns(data=data, sheet_name="Sheet")
+
+    expected_columns = [name for i in range(105) for name in (f"Field{i}GUID", f"Field{i}Number")]
+    assert list(result.columns) == expected_columns
+    assert result.loc[0, "Field0Number"] == 0
+    assert result.loc[0, "Field104Number"] == 104
+
+
+def test_process_uuid_columns_updates_existing_number_column():
+    data = pd.DataFrame({"NodeGUID": ["guid-a", "guid-b"], "NodeNumber": [-1, -1], "Name": ["A", "B"]})
+    store = ExcelFileStore()
+
+    result = store._process_uuid_columns(data=data, sheet_name="Sheet")
+
+    expected = pd.DataFrame({"NodeGUID": ["guid-a", "guid-b"], "NodeNumber": [0, 1], "Name": ["A", "B"]})
+    pd.testing.assert_frame_equal(result, expected)
+
+
+def test_process_uuid_columns_preserves_multi_index_columns():
+    columns = pd.MultiIndex.from_tuples([("NodeGUID", ""), ("Name", "text")], names=["field", "unit"])
+    data = pd.DataFrame([["guid-a", "A"]], columns=columns)
+    store = ExcelFileStore()
+
+    result = store._process_uuid_columns(data=data, sheet_name="Sheet")
+
+    expected_columns = pd.MultiIndex.from_tuples(
+        [("NodeGUID", ""), ("NodeNumber", ""), ("Name", "text")], names=["field", "unit"]
+    )
+    expected = pd.DataFrame([["guid-a", 0, "A"]], columns=expected_columns)
+    pd.testing.assert_frame_equal(result, expected)
 
 
 @patch("power_grid_model_io.data_stores.excel_file_store.ExcelFileStore._check_duplicate_values")

--- a/tests/unit/data_stores/test_excel_file_store.py
+++ b/tests/unit/data_stores/test_excel_file_store.py
@@ -319,8 +319,11 @@ def test_process_uuid_columns_batches_insertions_without_fragmentation_warning()
     assert result.loc[0, "Field104Number"] == 104
 
 
-def test_process_uuid_columns_updates_existing_number_column():
-    data = pd.DataFrame({"NodeGUID": ["guid-a", "guid-b"], "NodeNumber": [-1, -1], "Name": ["A", "B"]})
+@pytest.mark.parametrize("dtype", ["int64", "object"])
+def test_process_uuid_columns_updates_existing_number_column(dtype):
+    data = pd.DataFrame(
+        {"NodeGUID": ["guid-a", "guid-b"], "NodeNumber": pd.Series([-1, -1], dtype=dtype), "Name": ["A", "B"]}
+    )
     store = ExcelFileStore()
 
     result = store._process_uuid_columns(data=data, sheet_name="Sheet")


### PR DESCRIPTION
Fixes #468.

Builds all generated Number columns in one concat operation instead of repeatedly inserting them. This removes pandas fragmentation warnings and preserves each GUID/Number pair's order, including MultiIndex inputs and existing Number columns.

Validation: 1,444 tests pass; focused tests, Ruff, MyPy, REUSE, and full pre-commit pass.
