### PR TITLE
Exclude Validation tests from unit tests action

### DIFF
--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -82,7 +82,7 @@ jobs:
         run: uv pip install power-grid-model-io==${{ needs.build-python.outputs.version }} --find-links=wheelhouse
 
       - name: Unit test and coverage
-        run: uv run --frozen --only-group test --no-editable pytest --verbose
+        run: uv run --frozen --only-group test --no-editable pytest tests/unit --verbose
 
   validation-tests:
     needs: build-python

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -34,7 +34,8 @@ jobs:
       - name: Test and Coverage
         run: |
           uv sync --frozen --no-default-groups --group test
-          uv run --frozen pytest
+          uv run --frozen pytest tests/unit
+          uv run --frozen pytest tests/validation --no-cov
 
           # Fix relative paths in coverage file
           # Known bug: https://community.sonarsource.com/t/sonar-on-github-actions-with-python-coverage-source-issue/36057

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,9 +25,15 @@ repos:
         entry: uv run --frozen mypy
         language: system
         pass_filenames: false
-      - id: pytest
-        name: pytest
-        entry: uv run --frozen pytest
+      - id: pytest_unit
+        name: pytest-Unit
+        entry: uv run --frozen pytest tests/unit
+        language: system
+        pass_filenames: false
+        always_run: true
+      - id: pytest_valid
+        name: pytest-Validation
+        entry: uv run --frozen pytest tests/validation --no-cov
         language: system
         pass_filenames: false
         always_run: true


### PR DESCRIPTION
In #451 validation tests were made to run by default with `pytest`, however, after this change validation tests are now included in the unit tests action. Because of this, validation tests are being executed twice and coverage is also being applied to the validation tests.

A failed validation test results in a failed unit test action.

This PR makes unit test action run unit tests explicitly with coverage, while validation tests will remain in validation test action without coverage.

### Checks

- [ ] If changes are related to CI/CD, are they verified via a manual run on this branch?